### PR TITLE
use machine format multiaddr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@multiformats/multiaddr": "^12.1.3",
         "debug": "^4.3.4",
         "ethers": "^5.7.2",
         "file-type": "^18.2.1",
@@ -1647,15 +1648,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@ipld/dag-json": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.1.tgz",
@@ -1669,15 +1661,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@ipld/dag-json/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@ipld/dag-pb": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
@@ -1685,15 +1668,6 @@
       "dependencies": {
         "multiformats": "^11.0.0"
       },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@ipld/dag-pb/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -2232,27 +2206,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/crypto/node_modules/uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-      "dependencies": {
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/interface-connection": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
@@ -2269,45 +2222,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-connection/node_modules/@multiformats/multiaddr": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
-      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/interfaces": "^3.3.1",
-        "dns-over-http-resolver": "^2.1.0",
-        "multiformats": "^11.0.0",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-connection/node_modules/uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-      "dependencies": {
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/interface-keychain": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.4.tgz",
@@ -2316,15 +2230,6 @@
         "@libp2p/interface-peer-id": "^2.0.0",
         "multiformats": "^11.0.0"
       },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-keychain/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -2351,15 +2256,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-peer-id/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/interface-peer-info": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.9.tgz",
@@ -2367,45 +2263,6 @@
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@multiformats/multiaddr": "^12.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-info/node_modules/@multiformats/multiaddr": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
-      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/interfaces": "^3.3.1",
-        "dns-over-http-resolver": "^2.1.0",
-        "multiformats": "^11.0.0",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-info/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/interface-peer-info/node_modules/uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-      "dependencies": {
-        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -2452,15 +2309,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/logger/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/peer-id": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.3.tgz",
@@ -2470,27 +2318,6 @@
         "@libp2p/interfaces": "^3.2.0",
         "multiformats": "^11.0.0",
         "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-id/node_modules/uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-      "dependencies": {
-        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -2544,38 +2371,9 @@
       }
     },
     "node_modules/@multiformats/multiaddr": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.5.0.tgz",
-      "integrity": "sha512-u4qHMyv25iAqCb9twJROoN1M8UDm8bureOCIzwz03fVhwJzV6DpgH1eFz9UAzDn7CpSShQ9SLS5MiC4hJjTfig==",
-      "dependencies": {
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr-to-uri": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.4.tgz",
-      "integrity": "sha512-y2XDH/h6U1hnkFNyt3NeJhUv+9PiXJlzC6RZOOzK2OY3JgM6l6RrPrOJ1Tc2Sn4Aw6b2aUKY4C6nN4h6j9/+Vg==",
-      "dependencies": {
-        "@multiformats/multiaddr": "^12.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/@multiformats/multiaddr": {
-      "version": "12.1.2",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
-      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.3.tgz",
+      "integrity": "sha512-rNcS3njkkSwuGF4x58L47jGH5kBXBfJPNsWnrt0gujhNYn6ReDt1je7vEU5/ddrVj0TStgxw+Hm+TkYDK0b60w==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
@@ -2590,21 +2388,12 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr-to-uri/node_modules/uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+    "node_modules/@multiformats/multiaddr-to-uri": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.4.tgz",
+      "integrity": "sha512-y2XDH/h6U1hnkFNyt3NeJhUv+9PiXJlzC6RZOOzK2OY3JgM6l6RrPrOJ1Tc2Sn4Aw6b2aUKY4C6nN4h6j9/+Vg==",
       "dependencies": {
-        "multiformats": "^11.0.0"
+        "@multiformats/multiaddr": "^12.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -6693,15 +6482,6 @@
         "multiformats": "^11.0.0"
       }
     },
-    "node_modules/dag-jose/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -9676,10 +9456,40 @@
         "iexec": "dist/esm/cli/cmd/iexec.js"
       }
     },
+    "node_modules/iexec/node_modules/@multiformats/multiaddr": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.5.0.tgz",
+      "integrity": "sha512-u4qHMyv25iAqCb9twJROoN1M8UDm8bureOCIzwz03fVhwJzV6DpgH1eFz9UAzDn7CpSShQ9SLS5MiC4hJjTfig==",
+      "dependencies": {
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "is-ip": "^5.0.0",
+        "multiformats": "^9.4.5",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/iexec/node_modules/aes-js": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
       "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+    },
+    "node_modules/iexec/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "node_modules/iexec/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -9887,27 +9697,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/interface-datastore/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/interface-datastore/node_modules/uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-      "dependencies": {
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/interface-store": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.0.tgz",
@@ -10037,27 +9826,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/ipfs-core-types/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-core-types/node_modules/uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-      "dependencies": {
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/ipfs-core-utils": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.18.0.tgz",
@@ -10100,27 +9868,6 @@
         "multiformats": "^11.0.0",
         "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-core-utils/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-core-utils/node_modules/uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-      "dependencies": {
-        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -11915,27 +11662,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/kubo-rpc-client/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/kubo-rpc-client/node_modules/uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-      "dependencies": {
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -12636,9 +12362,13 @@
       "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
     },
     "node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/multihashes": {
       "version": "0.4.21",
@@ -15982,16 +15712,7 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/uint8arraylist/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/uint8arraylist/node_modules/uint8arrays": {
+    "node_modules/uint8arrays": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
       "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
@@ -16001,14 +15722,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-      "dependencies": {
-        "multiformats": "^9.4.2"
       }
     },
     "node_modules/ultron": {
@@ -18284,13 +17997,6 @@
       "requires": {
         "cborg": "^1.10.0",
         "multiformats": "^11.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        }
       }
     },
     "@ipld/dag-json": {
@@ -18300,13 +18006,6 @@
       "requires": {
         "cborg": "^1.10.0",
         "multiformats": "^11.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        }
       }
     },
     "@ipld/dag-pb": {
@@ -18315,13 +18014,6 @@
       "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
       "requires": {
         "multiformats": "^11.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -18739,21 +18431,6 @@
         "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.4.3",
         "uint8arrays": "^4.0.2"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        },
-        "uint8arrays": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-          "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-          "requires": {
-            "multiformats": "^11.0.0"
-          }
-        }
       }
     },
     "@libp2p/interface-connection": {
@@ -18766,35 +18443,6 @@
         "@multiformats/multiaddr": "^12.0.0",
         "it-stream-types": "^1.0.4",
         "uint8arraylist": "^2.1.2"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "12.1.2",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
-          "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
-          "requires": {
-            "@chainsafe/is-ip": "^2.0.1",
-            "@chainsafe/netmask": "^2.0.0",
-            "@libp2p/interfaces": "^3.3.1",
-            "dns-over-http-resolver": "^2.1.0",
-            "multiformats": "^11.0.0",
-            "uint8arrays": "^4.0.2",
-            "varint": "^6.0.0"
-          }
-        },
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        },
-        "uint8arrays": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-          "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-          "requires": {
-            "multiformats": "^11.0.0"
-          }
-        }
       }
     },
     "@libp2p/interface-keychain": {
@@ -18804,13 +18452,6 @@
       "requires": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "multiformats": "^11.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        }
       }
     },
     "@libp2p/interface-keys": {
@@ -18824,13 +18465,6 @@
       "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
       "requires": {
         "multiformats": "^11.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        }
       }
     },
     "@libp2p/interface-peer-info": {
@@ -18840,35 +18474,6 @@
       "requires": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@multiformats/multiaddr": "^12.0.0"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "12.1.2",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
-          "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
-          "requires": {
-            "@chainsafe/is-ip": "^2.0.1",
-            "@chainsafe/netmask": "^2.0.0",
-            "@libp2p/interfaces": "^3.3.1",
-            "dns-over-http-resolver": "^2.1.0",
-            "multiformats": "^11.0.0",
-            "uint8arrays": "^4.0.2",
-            "varint": "^6.0.0"
-          }
-        },
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        },
-        "uint8arrays": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-          "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-          "requires": {
-            "multiformats": "^11.0.0"
-          }
-        }
       }
     },
     "@libp2p/interface-pubsub": {
@@ -18897,13 +18502,6 @@
         "debug": "^4.3.3",
         "interface-datastore": "^8.0.0",
         "multiformats": "^11.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        }
       }
     },
     "@libp2p/peer-id": {
@@ -18915,21 +18513,6 @@
         "@libp2p/interfaces": "^3.2.0",
         "multiformats": "^11.0.0",
         "uint8arrays": "^4.0.2"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        },
-        "uint8arrays": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-          "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-          "requires": {
-            "multiformats": "^11.0.0"
-          }
-        }
       }
     },
     "@metamask/eth-sig-util": {
@@ -18978,15 +18561,16 @@
       }
     },
     "@multiformats/multiaddr": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.5.0.tgz",
-      "integrity": "sha512-u4qHMyv25iAqCb9twJROoN1M8UDm8bureOCIzwz03fVhwJzV6DpgH1eFz9UAzDn7CpSShQ9SLS5MiC4hJjTfig==",
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.3.tgz",
+      "integrity": "sha512-rNcS3njkkSwuGF4x58L47jGH5kBXBfJPNsWnrt0gujhNYn6ReDt1je7vEU5/ddrVj0TStgxw+Hm+TkYDK0b60w==",
       "requires": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
         "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "is-ip": "^5.0.0",
-        "multiformats": "^9.4.5",
-        "uint8arrays": "^3.0.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
       }
     },
@@ -18996,35 +18580,6 @@
       "integrity": "sha512-y2XDH/h6U1hnkFNyt3NeJhUv+9PiXJlzC6RZOOzK2OY3JgM6l6RrPrOJ1Tc2Sn4Aw6b2aUKY4C6nN4h6j9/+Vg==",
       "requires": {
         "@multiformats/multiaddr": "^12.0.0"
-      },
-      "dependencies": {
-        "@multiformats/multiaddr": {
-          "version": "12.1.2",
-          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
-          "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
-          "requires": {
-            "@chainsafe/is-ip": "^2.0.1",
-            "@chainsafe/netmask": "^2.0.0",
-            "@libp2p/interfaces": "^3.3.1",
-            "dns-over-http-resolver": "^2.1.0",
-            "multiformats": "^11.0.0",
-            "uint8arrays": "^4.0.2",
-            "varint": "^6.0.0"
-          }
-        },
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        },
-        "uint8arrays": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-          "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-          "requires": {
-            "multiformats": "^11.0.0"
-          }
-        }
       }
     },
     "@noble/ed25519": {
@@ -22250,13 +21805,6 @@
       "requires": {
         "@ipld/dag-cbor": "^9.0.0",
         "multiformats": "^11.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        }
       }
     },
     "dashdash": {
@@ -24541,10 +24089,36 @@
         "yup": "^1.0.1"
       },
       "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.5.0.tgz",
+          "integrity": "sha512-u4qHMyv25iAqCb9twJROoN1M8UDm8bureOCIzwz03fVhwJzV6DpgH1eFz9UAzDn7CpSShQ9SLS5MiC4hJjTfig==",
+          "requires": {
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "is-ip": "^5.0.0",
+            "multiformats": "^9.4.5",
+            "uint8arrays": "^3.0.0",
+            "varint": "^6.0.0"
+          }
+        },
         "aes-js": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
           "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+        },
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        },
+        "uint8arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
         }
       }
     },
@@ -24687,21 +24261,6 @@
         "interface-store": "^5.0.0",
         "nanoid": "^4.0.0",
         "uint8arrays": "^4.0.2"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        },
-        "uint8arrays": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-          "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-          "requires": {
-            "multiformats": "^11.0.0"
-          }
-        }
       }
     },
     "interface-store": {
@@ -24794,19 +24353,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
           "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
-        },
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        },
-        "uint8arrays": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-          "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-          "requires": {
-            "multiformats": "^11.0.0"
-          }
         }
       }
     },
@@ -24848,19 +24394,6 @@
             "multiformats": "^11.0.0",
             "uint8arrays": "^4.0.2",
             "varint": "^6.0.0"
-          }
-        },
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        },
-        "uint8arrays": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-          "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-          "requires": {
-            "multiformats": "^11.0.0"
           }
         }
       }
@@ -26172,19 +25705,6 @@
             "uint8arrays": "^4.0.2",
             "varint": "^6.0.0"
           }
-        },
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        },
-        "uint8arrays": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-          "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-          "requires": {
-            "multiformats": "^11.0.0"
-          }
         }
       }
     },
@@ -26726,9 +26246,9 @@
       }
     },
     "multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
     },
     "multihashes": {
       "version": "0.4.21",
@@ -29196,29 +28716,14 @@
       "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
       "requires": {
         "uint8arrays": "^4.0.2"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        },
-        "uint8arrays": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-          "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-          "requires": {
-            "multiformats": "^11.0.0"
-          }
-        }
       }
     },
     "uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
       "requires": {
-        "multiformats": "^9.4.2"
+        "multiformats": "^11.0.0"
       }
     },
     "ultron": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
+    "@multiformats/multiaddr": "^12.1.3",
     "debug": "^4.3.4",
     "ethers": "^5.7.2",
     "file-type": "^18.2.1",

--- a/src/dataProtector/protectDataObservable.ts
+++ b/src/dataProtector/protectDataObservable.ts
@@ -5,6 +5,7 @@ import {
   DataObject,
 } from './types.js';
 import { ethers } from 'ethers';
+import { multiaddr as Multiaddr } from '@multiformats/multiaddr';
 import {
   CONTRACT_ADDRESS,
   DEFAULT_IEXEC_IPFS_NODE,
@@ -127,7 +128,7 @@ export const protectDataObservable = ({
           await iexec.config.resolveContractsClient();
 
         const contract = new ethers.Contract(CONTRACT_ADDRESS, ABI, provider);
-        const multiaddrBytes = ethers.utils.toUtf8Bytes(multiaddr);
+        const multiaddrBytes = Multiaddr(multiaddr).bytes;
         const ownerAddress = await signer.getAddress();
 
         if (abort) return;


### PR DESCRIPTION
`multiaddr` was utf8 encoded string which is not compatible with the iExec worker, the latter expects either a machine-readable multiaddr or a plain URL.
this PR set the `multiaddr` as a machine-readable multiaddr.