### PR TITLE
Refacto/clean ci pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -46,6 +46,8 @@ trigger:
     - promote
   target:
     - nightly
+  branch:
+    - develop
 
 steps:
   - name: install
@@ -85,9 +87,6 @@ steps:
         from_secret: npm_token
       tag: nightly
       access: public
-    when:
-      branch:
-        - develop
 
 ---
 kind: pipeline
@@ -99,6 +98,8 @@ trigger:
     - promote
   target:
     - latest
+  branch:
+    - main
 
 steps:
   - name: install
@@ -133,6 +134,3 @@ steps:
         from_secret: npm_token
       tag: latest
       access: public
-    when:
-      branch:
-        - main


### PR DESCRIPTION
Changes:
- remove useless `-` in pipeline and step names
- remove useless pull always when the same image is pulled ina the previous step
- move npm publish dry-run in default pipeline (useful to see the package before actually promoting for a real publication)
- block promote pipeline on the wrong branch (previously only the publish step was deactivated)