### PR TITLE
Fix/missing observable type

### DIFF
--- a/src/dataProtector/protectDataObservable.ts
+++ b/src/dataProtector/protectDataObservable.ts
@@ -52,7 +52,7 @@ export const protectDataObservable = ({
     throw new ValidationError(`data is not valid: ${e.message}`);
   }
 
-  const observable = new Observable((observer) => {
+  const observable = new Observable<ProtectDataMessage>((observer) => {
     let abort = false;
     const safeObserver: SafeObserver<ProtectDataMessage> = new SafeObserver(
       observer

--- a/src/dataProtector/revokeAllAccessObservable.ts
+++ b/src/dataProtector/revokeAllAccessObservable.ts
@@ -32,7 +32,7 @@ export const revokeAllAccessObservable = ({
     .required()
     .label('authorizedUser')
     .validateSync(authorizedUser);
-  const observable = new Observable((observer) => {
+  const observable = new Observable<RevokeAllAccessMessage>((observer) => {
     let abort = false;
     const safeObserver: SafeObserver<RevokeAllAccessMessage> = new SafeObserver(
       observer

--- a/src/utils/reactive.ts
+++ b/src/utils/reactive.ts
@@ -50,13 +50,27 @@ class SafeObserver<DataMessageType> {
   }
 }
 
+type ObservableNext<DataMessageType> = (data: DataMessageType) => void;
+type ObservableError = (e: Error) => void;
+type ObservableComplete = () => void;
+
+type Observer<DataMessageType> = {
+  next: ObservableNext<DataMessageType>;
+  error: ObservableError;
+  complete: ObservableComplete;
+};
+
 class Observable<DataMessageType> {
   private _subscribe;
 
   constructor(_subscribe) {
     this._subscribe = _subscribe;
   }
-  subscribe(observerOrNext, error, complete) {
+  subscribe(
+    observerOrNext: Observer<DataMessageType> | ObservableNext<DataMessageType>,
+    error?: ObservableError,
+    complete?: ObservableComplete
+  ) {
     const safeObserver: SafeObserver<DataMessageType> = new SafeObserver(
       observerOrNext
     );


### PR DESCRIPTION
## Add types for Observable

before:
- only `subscribe(next, error, complete)` is recognized by ts (not `subscribe({next, error, complete})`)
- callback are not typed
![image](https://github.com/iExecBlockchainComputing/dataprotector-sdk/assets/26487010/9c2b1c36-a237-4786-9cce-0bb4200179c0)

after:
- callbacks are typed
![image](https://github.com/iExecBlockchainComputing/dataprotector-sdk/assets/26487010/0862766e-7984-4ae3-aeec-542304c749e1)
- ts recognize the interface `subscribe({next, error, complete})`
![image](https://github.com/iExecBlockchainComputing/dataprotector-sdk/assets/26487010/310ddd39-e3f0-44b8-b3d5-8b80cc01f051)

**NB: observable types are voluntarily not directly exposed**

## Other

- make private the internal variable `_subscribe` to no expose it