### PR TITLE
remove framework gramine from data protector

### DIFF
--- a/src/dataProtector/grantAccess.ts
+++ b/src/dataProtector/grantAccess.ts
@@ -18,9 +18,6 @@ export const inferTagFromAppMREnclave = (mrenclave: string) => {
       case 'scone':
         tag.push('scone');
         return tag;
-      case 'gramine':
-        tag.push('gramine');
-        return tag;
       default:
         break;
     }

--- a/src/dataProtector/protectDataObservable.ts
+++ b/src/dataProtector/protectDataObservable.ts
@@ -184,26 +184,6 @@ export const protectDataObservable = ({
           message: 'PUSH_SECRET_TO_SMS_SUCCESS',
           teeFramework: 'scone',
         });
-        // share secret with gramine SMS
-        safeObserver.next({
-          message: 'PUSH_SECRET_TO_SMS_REQUEST',
-          teeFramework: 'gramine',
-        });
-        await iexec.dataset
-          .pushDatasetSecret(protectedDataAddress, encryptionKey, {
-            teeFramework: 'gramine',
-          })
-          .catch((e: Error) => {
-            throw new WorkflowError(
-              'Failed to push protected data encryption key',
-              e
-            );
-          });
-        if (abort) return;
-        safeObserver.next({
-          message: 'PUSH_SECRET_TO_SMS_SUCCESS',
-          teeFramework: 'gramine',
-        });
         safeObserver.complete();
       } catch (e: any) {
         logger.log(e);

--- a/tests/e2e/IExecDataProtector/grantAccess.test.ts
+++ b/tests/e2e/IExecDataProtector/grantAccess.test.ts
@@ -17,7 +17,6 @@ describe('dataProtector.grantAccess()', () => {
   let protectedData: ProtectedDataWithSecretProps;
   let nonTeeAppAddress: string;
   let sconeAppAddress: string;
-  let gramineAppAddress: string;
 
   beforeAll(async () => {
     wallet = Wallet.createRandom();
@@ -27,13 +26,11 @@ describe('dataProtector.grantAccess()', () => {
         data: { doNotUse: 'test' },
       }),
       deployRandomApp(),
-      deployRandomApp({ teeFramework: 'scone' }),
-      deployRandomApp({ teeFramework: 'gramine' }),
+      deployRandomApp({ teeFramework: 'scone' })
     ]);
     protectedData = results[0];
     nonTeeAppAddress = results[1];
     sconeAppAddress = results[2];
-    gramineAppAddress = results[3];
   }, 4 * MAX_EXPECTED_BLOCKTIME);
 
   let input: any;
@@ -58,15 +55,6 @@ describe('dataProtector.grantAccess()', () => {
     expect(grantedAccess.tag).toBe(
       '0x0000000000000000000000000000000000000000000000000000000000000003'
     ); // ['tee', 'scone']
-  });
-  it('infers the tag to use with a Gramine app', async () => {
-    const grantedAccess = await dataProtector.grantAccess({
-      ...input,
-      authorizedApp: gramineAppAddress,
-    });
-    expect(grantedAccess.tag).toBe(
-      '0x0000000000000000000000000000000000000000000000000000000000000005'
-    ); // ['tee', 'gramine']
   });
   it('checks protectedData is required address or ENS', async () => {
     await expect(

--- a/tests/e2e/IExecDataProtector/protectDataObservable.test.ts
+++ b/tests/e2e/IExecDataProtector/protectDataObservable.test.ts
@@ -124,7 +124,7 @@ describe('dataProtector.protectDataObservable()', () => {
         expect(error).toBeUndefined();
         expect(completed).toBe(true);
 
-        expect(messages.length).toBe(11);
+        expect(messages.length).toBe(9);
 
         expect(messages[0].message).toBe('DATA_SCHEMA_EXTRACTED');
         expect(messages[0].schema).toStrictEqual(expectedSchema);
@@ -157,12 +157,6 @@ describe('dataProtector.protectDataObservable()', () => {
 
         expect(messages[8].message).toBe('PUSH_SECRET_TO_SMS_SUCCESS');
         expect(messages[8].teeFramework).toBe('scone');
-
-        expect(messages[9].message).toBe('PUSH_SECRET_TO_SMS_REQUEST');
-        expect(messages[9].teeFramework).toBe('gramine');
-
-        expect(messages[10].message).toBe('PUSH_SECRET_TO_SMS_SUCCESS');
-        expect(messages[10].teeFramework).toBe('gramine');
       },
       2 * MAX_EXPECTED_BLOCKTIME
     );


### PR DESCRIPTION
Besides removing secret pushing with protectData(), the method grantAccess had support removed for the framework 'gramine', since it would fail at creating a dataset order for gramine with checkDatasetSecretExists