### PR TITLE
setup default page size & page number configuration

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -16,5 +16,3 @@ export const SCONE_TAG = ['tee', 'scone'];
 export const DEFAULT_MAX_PRICE = 0;
 export const ADD_RESOURCE_SELECTOR = 'addResourceToWhitelist(address)';
 export const KEY_PURPOSE_SELECTOR = 'keyHasPurpose(bytes32,uint256)';
-export const DEFAULT_PAGE_SIZE = '1000';
-export const DEFAULT_PAGE = '0';

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -16,3 +16,5 @@ export const SCONE_TAG = ['tee', 'scone'];
 export const DEFAULT_MAX_PRICE = 0;
 export const ADD_RESOURCE_SELECTOR = 'addResourceToWhitelist(address)';
 export const KEY_PURPOSE_SELECTOR = 'keyHasPurpose(bytes32,uint256)';
+export const DEFAULT_PAGE_SIZE = '1000';
+export const DEFAULT_PAGE = '0';

--- a/src/dataProtector/fetchProtectedData.ts
+++ b/src/dataProtector/fetchProtectedData.ts
@@ -5,8 +5,8 @@ import {
 } from '../utils/data.js';
 import { ValidationError, WorkflowError } from '../utils/errors.js';
 import {
-  PageSizeStringSchema,
   addressSchema,
+  pageSizeStringSchema,
   positiveIntegerStringSchema,
   throwIfMissing,
 } from '../utils/validators.js';
@@ -45,7 +45,7 @@ export const fetchProtectedData = async ({
   }
   const vOwner: string = addressSchema().label('owner').validateSync(owner);
   const vPage = positiveIntegerStringSchema().label('page').validateSync(page);
-  const vPageSize = PageSizeStringSchema()
+  const vPageSize = pageSizeStringSchema()
     .label('pageSize')
     .validateSync(pageSize);
   try {

--- a/src/dataProtector/fetchProtectedData.ts
+++ b/src/dataProtector/fetchProtectedData.ts
@@ -7,7 +7,7 @@ import { ValidationError, WorkflowError } from '../utils/errors.js';
 import {
   addressSchema,
   numberBetweenSchema,
-  numberNonNegativeSchema,
+  positiveNumberSchema,
   throwIfMissing,
 } from '../utils/validators.js';
 import {
@@ -44,7 +44,7 @@ export const fetchProtectedData = async ({
     throw new ValidationError(`schema is not valid: ${e.message}`);
   }
   const vOwner: string = addressSchema().label('owner').validateSync(owner);
-  const vPage = numberNonNegativeSchema().label('page').validateSync(page);
+  const vPage = positiveNumberSchema().label('page').validateSync(page);
   const vPageSize = numberBetweenSchema(10, 1000)
     .label('pageSize')
     .validateSync(pageSize);

--- a/src/dataProtector/fetchProtectedData.ts
+++ b/src/dataProtector/fetchProtectedData.ts
@@ -6,8 +6,8 @@ import {
 import { ValidationError, WorkflowError } from '../utils/errors.js';
 import {
   addressSchema,
-  pageSizeStringSchema,
-  positiveIntegerStringSchema,
+  numberBetweenSchema,
+  numberNonNegativeSchema,
   throwIfMissing,
 } from '../utils/validators.js';
 import {
@@ -33,8 +33,8 @@ export const fetchProtectedData = async ({
   graphQLClient = throwIfMissing(),
   requiredSchema = {},
   owner,
-  page = DEFAULT_PAGE,
-  pageSize = DEFAULT_PAGE_SIZE,
+  page = 0,
+  pageSize = 1000,
 }: FetchProtectedDataParams & SubgraphConsumer): Promise<ProtectedData[]> => {
   let vRequiredSchema: DataSchema;
   try {
@@ -44,13 +44,13 @@ export const fetchProtectedData = async ({
     throw new ValidationError(`schema is not valid: ${e.message}`);
   }
   const vOwner: string = addressSchema().label('owner').validateSync(owner);
-  const vPage = positiveIntegerStringSchema().label('page').validateSync(page);
-  const vPageSize = pageSizeStringSchema()
+  const vPage = numberNonNegativeSchema().label('page').validateSync(page);
+  const vPageSize = numberBetweenSchema(10, 1000)
     .label('pageSize')
     .validateSync(pageSize);
   try {
-    const start = +vPage * +vPageSize;
-    const range = +vPageSize;
+    const start = vPage * vPageSize;
+    const range = vPageSize;
 
     const schemaArray = flattenSchema(vRequiredSchema);
     const SchemaFilteredProtectedData = gql`

--- a/src/dataProtector/types.ts
+++ b/src/dataProtector/types.ts
@@ -306,8 +306,8 @@ export type ProtectedDataWithSecretProps = ProtectedData &
 export type FetchProtectedDataParams = {
   requiredSchema?: DataSchema;
   owner?: string;
-  page?: string;
-  pageSize?: string;
+  page?: number;
+  pageSize?: number;
 };
 
 /**

--- a/src/dataProtector/types.ts
+++ b/src/dataProtector/types.ts
@@ -306,6 +306,8 @@ export type ProtectedDataWithSecretProps = ProtectedData &
 export type FetchProtectedDataParams = {
   requiredSchema?: DataSchema;
   owner?: string;
+  page?: string;
+  pageSize?: string;
 };
 
 /**

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -55,8 +55,10 @@ export const positiveIntegerStringSchema = () =>
     '${path} should be a positive integer',
     (value) => isUndefined(value) || isPositiveIntegerStringTest(value)
   );
-export const numberNonNegativeSchema = () =>
-  number().integer().min(0).typeError(`$\{path} must be a non-negative number`);
+
+export const positiveNumberSchema = () =>
+  number().integer().min(0).typeError('${path} must be a non-negative number');
+
 export const numberBetweenSchema = (min: number, max: number) =>
   number()
     .integer()
@@ -87,9 +89,6 @@ export const grantedAccessSchema = () =>
   })
     .noUnknown()
     .default(undefined);
-
-export const positiveNumberSchema = () =>
-  number().integer().min(0).typeError('${path} must be a non-negative number');
 
 export const urlArraySchema = () => array().of(urlSchema());
 

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -11,8 +11,6 @@ const isEnsTest = (value: string) => value.endsWith('.eth') && value.length > 6;
 const isAnyTest = (value: string) => value === 'any';
 
 const isPositiveIntegerStringTest = (value: string) => /^\d+$/.test(value);
-const isBetween10And1000Test = (value: string) =>
-  /^(?!0*$)([1-9]\d{0,2}|1000)$/.test(value);
 const isZeroStringTest = (value: string) => value === '0';
 
 export const stringSchema = () =>

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -57,14 +57,14 @@ export const positiveIntegerStringSchema = () =>
     '${path} should be a positive integer',
     (value) => isUndefined(value) || isPositiveIntegerStringTest(value)
   );
-export const pageSizeStringSchema = () =>
-  string().test(
-    'is-between-10-and-1000',
-    '${path} should be a positive integer and should be between 10 and 1000',
-    (value) =>
-      isUndefined(value) ||
-      (isPositiveIntegerStringTest(value) && isBetween10And1000Test(value))
-  );
+export const numberNonNegativeSchema = () =>
+  number().integer().min(0).typeError(`$\{path} must be a non-negative number`);
+export const numberBetweenSchema = (min: number, max: number) =>
+  number()
+    .integer()
+    .min(min)
+    .max(max)
+    .typeError(`$\{path} must be a number between ${min} and ${max}`);
 
 export const positiveStrictIntegerStringSchema = () =>
   string().test(

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,5 +1,5 @@
 import { isAddress } from 'ethers';
-import { ValidationError, number, object, string, array } from 'yup';
+import { ValidationError, array, number, object, string } from 'yup';
 
 export const throwIfMissing = (): never => {
   throw new ValidationError('Missing parameter');
@@ -11,6 +11,8 @@ const isEnsTest = (value: string) => value.endsWith('.eth') && value.length > 6;
 const isAnyTest = (value: string) => value === 'any';
 
 const isPositiveIntegerStringTest = (value: string) => /^\d+$/.test(value);
+const isBetween10And1000Test = (value: string) =>
+  /^(?!0*$)([1-9]\d{0,2}|1000)$/.test(value);
 const isZeroStringTest = (value: string) => value === '0';
 
 export const stringSchema = () =>
@@ -54,6 +56,14 @@ export const positiveIntegerStringSchema = () =>
     'is-positive-int',
     '${path} should be a positive integer',
     (value) => isUndefined(value) || isPositiveIntegerStringTest(value)
+  );
+export const PageSizeStringSchema = () =>
+  string().test(
+    'is-positive-int',
+    '${path} should be a positive integer and should be between 10 and 1000',
+    (value) =>
+      isUndefined(value) ||
+      (isPositiveIntegerStringTest(value) && isBetween10And1000Test(value))
   );
 
 export const positiveStrictIntegerStringSchema = () =>

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -57,9 +57,9 @@ export const positiveIntegerStringSchema = () =>
     '${path} should be a positive integer',
     (value) => isUndefined(value) || isPositiveIntegerStringTest(value)
   );
-export const PageSizeStringSchema = () =>
+export const pageSizeStringSchema = () =>
   string().test(
-    'is-positive-int',
+    'is-between-10-and-1000',
     '${path} should be a positive integer and should be between 10 and 1000',
     (value) =>
       isUndefined(value) ||

--- a/tests/e2e/IExecDataProtector/fetchProtectedData.test.ts
+++ b/tests/e2e/IExecDataProtector/fetchProtectedData.test.ts
@@ -7,6 +7,7 @@ import { MAX_EXPECTED_BLOCKTIME } from '../../test-utils.js';
 describe('dataProtector.fetchProtectedData()', () => {
   let dataProtector: IExecDataProtector;
   let wallet: HDNodeWallet;
+
   beforeEach(async () => {
     wallet = Wallet.createRandom();
     dataProtector = new IExecDataProtector(getWeb3Provider(wallet.privateKey));
@@ -62,10 +63,12 @@ describe('dataProtector.fetchProtectedData()', () => {
       new ValidationError('owner should be an ethereum address')
     );
   });
+
   it('pagination: fetches the first 1000 items by default', async () => {
     const res = await dataProtector.fetchProtectedData();
     expect(res.length).toBe(1000);
   });
+
   it('pagination: fetches a specific page with a specified page size', async () => {
     const page = 2; // Specify the desired page number
     const pageSize = 50; // Specify the desired page size
@@ -80,6 +83,7 @@ describe('dataProtector.fetchProtectedData()', () => {
     });
     expect(res[49]).toEqual(res2ToCheck[149]);
   });
+
   it('pagination: handles invalid page numbers gracefully', async () => {
     const page = -1; // Invalid page number
     const pageSize = 50; // Specify a valid page size

--- a/tests/e2e/IExecDataProtector/fetchProtectedData.test.ts
+++ b/tests/e2e/IExecDataProtector/fetchProtectedData.test.ts
@@ -73,7 +73,12 @@ describe('dataProtector.fetchProtectedData()', () => {
 
     // Check if the correct number of items for the specified page size is retrieved
     expect(res.length).toBe(50);
-    // TODO: implement logic to ensure that the items are from the desired page.
+
+    const res2ToCheck = await dataProtector.fetchProtectedData({
+      page: 0,
+      pageSize: 150,
+    });
+    expect(res[49]).toEqual(res2ToCheck[149]);
   });
   it('pagination: handles invalid page numbers gracefully', async () => {
     const page = -1; // Invalid page number

--- a/tests/e2e/IExecDataProtector/fetchProtectedData.test.ts
+++ b/tests/e2e/IExecDataProtector/fetchProtectedData.test.ts
@@ -67,8 +67,8 @@ describe('dataProtector.fetchProtectedData()', () => {
     expect(res.length).toBe(1000);
   });
   it('pagination: fetches a specific page with a specified page size', async () => {
-    const page = '2'; // Specify the desired page number
-    const pageSize = '50'; // Specify the desired page size
+    const page = 2; // Specify the desired page number
+    const pageSize = 50; // Specify the desired page size
     const res = await dataProtector.fetchProtectedData({ page, pageSize });
 
     // Check if the correct number of items for the specified page size is retrieved
@@ -76,16 +76,18 @@ describe('dataProtector.fetchProtectedData()', () => {
     // TODO: implement logic to ensure that the items are from the desired page.
   });
   it('pagination: handles invalid page numbers gracefully', async () => {
-    const page = '-1'; // Invalid page number
-    const pageSize = '50'; // Specify a valid page size
+    const page = -1; // Invalid page number
+    const pageSize = 50; // Specify a valid page size
     await expect(
       dataProtector.fetchProtectedData({ page, pageSize })
-    ).rejects.toThrow(new ValidationError('page should be a positive integer'));
+    ).rejects.toThrow(
+      new ValidationError('page must be greater than or equal to 0')
+    );
   });
 
   it('pagination: handles large page numbers correctly', async () => {
-    const page = '10000'; // Large page number
-    const pageSize = '50'; // Specify a valid page size
+    const page = 10000; // Large page number
+    const pageSize = 50; // Specify a valid page size
     const res = await dataProtector.fetchProtectedData({ page, pageSize });
 
     // Check if the response is empty
@@ -93,15 +95,13 @@ describe('dataProtector.fetchProtectedData()', () => {
   });
 
   it('pagination: handles large page sizes correctly', async () => {
-    const page = '1'; // Specify a valid page number
-    const pageSize = '10000'; // large page size
+    const page = 1; // Specify a valid page number
+    const pageSize = 10000; // large page size
 
     await expect(
       dataProtector.fetchProtectedData({ page, pageSize })
     ).rejects.toThrow(
-      new ValidationError(
-        'pageSize should be a positive integer and should be between 10 and 1000'
-      )
+      new ValidationError('pageSize must be less than or equal to 1000')
     );
   });
 });

--- a/tests/e2e/IExecDataProtector/fetchProtectedData.test.ts
+++ b/tests/e2e/IExecDataProtector/fetchProtectedData.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, expect } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { HDNodeWallet, Wallet } from 'ethers';
 import { IExecDataProtector, getWeb3Provider } from '../../../src/index.js';
 import { ValidationError } from '../../../src/utils/errors.js';
@@ -60,6 +60,48 @@ describe('dataProtector.fetchProtectedData()', () => {
       dataProtector.fetchProtectedData({ owner: 'not an address' })
     ).rejects.toThrow(
       new ValidationError('owner should be an ethereum address')
+    );
+  });
+  it('pagination: fetches the first 1000 items by default', async () => {
+    const res = await dataProtector.fetchProtectedData();
+    expect(res.length).toBe(1000);
+  });
+  it('pagination: fetches a specific page with a specified page size', async () => {
+    const page = '2'; // Specify the desired page number
+    const pageSize = '50'; // Specify the desired page size
+    const res = await dataProtector.fetchProtectedData({ page, pageSize });
+
+    // Check if the correct number of items for the specified page size is retrieved
+    expect(res.length).toBe(50);
+    // TODO: implement logic to ensure that the items are from the desired page.
+  });
+  it('pagination: handles invalid page numbers gracefully', async () => {
+    const page = '-1'; // Invalid page number
+    const pageSize = '50'; // Specify a valid page size
+    await expect(
+      dataProtector.fetchProtectedData({ page, pageSize })
+    ).rejects.toThrow(new ValidationError('page should be a positive integer'));
+  });
+
+  it('pagination: handles large page numbers correctly', async () => {
+    const page = '10000'; // Large page number
+    const pageSize = '50'; // Specify a valid page size
+    const res = await dataProtector.fetchProtectedData({ page, pageSize });
+
+    // Check if the response is empty
+    expect(res).toStrictEqual([]);
+  });
+
+  it('pagination: handles large page sizes correctly', async () => {
+    const page = '1'; // Specify a valid page number
+    const pageSize = '10000'; // large page size
+
+    await expect(
+      dataProtector.fetchProtectedData({ page, pageSize })
+    ).rejects.toThrow(
+      new ValidationError(
+        'pageSize should be a positive integer and should be between 10 and 1000'
+      )
     );
   });
 });

--- a/tests/unit/utils/validators.test.ts
+++ b/tests/unit/utils/validators.test.ts
@@ -9,6 +9,7 @@ import {
   grantedAccessSchema,
   secretsSchema,
   positiveNumberSchema,
+  numberBetweenSchema,
   validateOrders,
 } from '../../../src/utils/validators.js';
 import {
@@ -549,6 +550,46 @@ describe('positiveNumberSchema()', () => {
       const schema = positiveNumberSchema().label('testNumber');
       const nonNumber = 'not a number';
       expect(() => schema.validateSync(nonNumber)).toThrow();
+    });
+  });
+});
+
+describe('numberBetweenSchema()', function () {
+  describe('validateSync()', () => {
+    it('should not accept a number below minimum', () => {
+      const schema = numberBetweenSchema(10, 20);
+      const tooLowNumber = 5;
+      expect(() => schema.validateSync(tooLowNumber)).toThrow();
+    });
+
+    it('should not accept a number above maximum', () => {
+      const schema = numberBetweenSchema(10, 20);
+      const tooLowNumber = 25;
+      expect(() => schema.validateSync(tooLowNumber)).toThrow();
+    });
+
+    it('should accept a number equals to the minimum', () => {
+      const schema = numberBetweenSchema(10, 20);
+      const tooLowNumber = 10;
+      expect(() => schema.validateSync(tooLowNumber)).not.toThrow();
+    });
+
+    it('should accept a number equals to the maximum', () => {
+      const schema = numberBetweenSchema(10, 20);
+      const tooLowNumber = 20;
+      expect(() => schema.validateSync(tooLowNumber)).not.toThrow();
+    });
+
+    it('should also accept a number as string', () => {
+      const schema = numberBetweenSchema(10, 20);
+      const tooLowNumber = '12';
+      expect(() => schema.validateSync(tooLowNumber)).not.toThrow();
+    });
+
+    it('should not accept any string that is not a number', () => {
+      const schema = numberBetweenSchema(10, 20);
+      const tooLowNumber = 'abc';
+      expect(() => schema.validateSync(tooLowNumber)).toThrow();
     });
   });
 });


### PR DESCRIPTION
Currently: fetchProtectedData returns the first 1000 results and cuts the next results.

Objectives:

Allow the user to access results beyond the 1000th item

Allow the user to fetch smaller results set

implemented pagination by adding page & pageSize optional parameters to fetchProtectedData . 

10 <= pageSize <= 1000 (default TBD)

0 <= page (default 0)

i setup default pageSize to 1000(TBD)

implemented e2e tests of the fetchProtectedData with pagination.