### PR TITLE
ESLint: Predictable imports order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,14 +9,19 @@
   "extends": [
     "airbnb-typescript/base",
     "plugin:@typescript-eslint/recommended",
-    "prettier",
+    "plugin:import/recommended",
     "plugin:sonarjs/recommended",
-    "plugin:jest/recommended"
+    "plugin:jest/recommended",
+    "prettier"
   ],
   "rules": {
     "sonarjs/cognitive-complexity": "warn",
     "@typescript-eslint/no-explicit-any": "warn",
-    "sonarjs/prefer-single-boolean-return": "warn"
+    "sonarjs/prefer-single-boolean-return": "warn",
+    "import/order": [
+      "warn",
+      { "alphabetize": { "order": "asc", "caseInsensitive": true } }
+    ]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,5 +37,10 @@
         "sonarjs/no-duplicate-string": "off"
       }
     }
-  ]
+  ],
+  "settings": {
+    "import/resolver": {
+      "typescript": {} // this loads <rootdir>/tsconfig.json to eslint
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint": "^8.51.0",
         "eslint-config-airbnb-typescript": "^17.1.0",
         "eslint-config-prettier": "^9.0.0",
+        "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-jest": "^27.4.2",
         "eslint-plugin-sonarjs": "^0.21.0",
@@ -3535,6 +3536,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/err-code": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
@@ -3791,6 +3805,31 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
+      "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
+        "fast-glob": "^3.3.1",
+        "get-tsconfig": "^4.5.0",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -4547,6 +4586,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+      "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -7772,6 +7823,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -8263,6 +8323,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check-types": "tsc --noEmit",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "check-format": "prettier --check \"src/**/*.ts\""
   },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "^8.51.0",
     "eslint-config-airbnb-typescript": "^17.1.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jest": "^27.4.2",
     "eslint-plugin-sonarjs": "^0.21.0",

--- a/src/dataProtector/IExecDataProtector.ts
+++ b/src/dataProtector/IExecDataProtector.ts
@@ -11,10 +11,12 @@ import { Observable } from '../utils/reactive.js';
 import { fetchGrantedAccess } from './fetchGrantedAccess.js';
 import { fetchProtectedData } from './fetchProtectedData.js';
 import { grantAccess } from './grantAccess.js';
+import { processProtectedData } from './processProtectedData.js';
 import { protectData } from './protectData.js';
 import { protectDataObservable } from './protectDataObservable.js';
 import { revokeAllAccessObservable } from './revokeAllAccessObservable.js';
 import { revokeOneAccess } from './revokeOneAccess.js';
+import { transferOwnership } from './transferOwnership.js';
 import {
   AddressOrENS,
   DataProtectorConfigOptions,
@@ -35,8 +37,6 @@ import {
   Web3SignerProvider,
   GrantedAccessResponse,
 } from './types.js';
-import { transferOwnership } from './transferOwnership.js';
-import { processProtectedData } from './processProtectedData.js';
 
 class IExecDataProtector {
   private contractAddress: AddressOrENS;

--- a/src/dataProtector/fetchGrantedAccess.ts
+++ b/src/dataProtector/fetchGrantedAccess.ts
@@ -1,14 +1,14 @@
+import { WorkflowError } from '../utils/errors.js';
+import { formatGrantedAccess } from '../utils/format.js';
+import {
+  addressOrEnsOrAnySchema,
+  throwIfMissing,
+} from '../utils/validators.js';
 import {
   FetchGrantedAccessParams,
   IExecConsumer,
   GrantedAccessResponse,
 } from './types.js';
-import { WorkflowError } from '../utils/errors.js';
-import {
-  addressOrEnsOrAnySchema,
-  throwIfMissing,
-} from '../utils/validators.js';
-import { formatGrantedAccess } from '../utils/format.js';
 
 export const fetchGrantedAccess = async ({
   iexec = throwIfMissing(),

--- a/src/dataProtector/fetchProtectedData.ts
+++ b/src/dataProtector/fetchProtectedData.ts
@@ -1,6 +1,10 @@
+import { gql } from 'graphql-request';
+import {
+  ensureDataSchemaIsValid,
+  transformGraphQLResponse,
+} from '../utils/data.js';
 import { ValidationError, WorkflowError } from '../utils/errors.js';
 import { addressSchema, throwIfMissing } from '../utils/validators.js';
-import { gql } from 'graphql-request';
 import {
   FetchProtectedDataParams,
   DataSchema,
@@ -8,10 +12,6 @@ import {
   SubgraphConsumer,
   GraphQLResponse,
 } from './types.js';
-import {
-  ensureDataSchemaIsValid,
-  transformGraphQLResponse,
-} from '../utils/data.js';
 
 function flattenSchema(schema: DataSchema, parentKey = ''): string[] {
   return Object.entries(schema).flatMap(([key, value]) => {

--- a/src/dataProtector/grantAccess.ts
+++ b/src/dataProtector/grantAccess.ts
@@ -7,9 +7,9 @@ import {
   positiveStrictIntegerStringSchema,
   throwIfMissing,
 } from '../utils/validators.js';
+import { isDeployedWhitelist } from '../utils/whitelist.js';
 import { fetchGrantedAccess } from './fetchGrantedAccess.js';
 import { GrantAccessParams, GrantedAccess, IExecConsumer } from './types.js';
-import { isDeployedWhitelist } from '../utils/whitelist.js';
 
 export const inferTagFromAppMREnclave = (mrenclave: string) => {
   const tag = ['tee'];

--- a/src/dataProtector/processProtectedData.ts
+++ b/src/dataProtector/processProtectedData.ts
@@ -3,6 +3,9 @@ import {
   SCONE_TAG,
   WORKERPOOL_ADDRESS,
 } from '../config/config.js';
+import { WorkflowError } from '../utils/errors.js';
+import { fetchOrdersUnderMaxPrice } from '../utils/fetchOrdersUnderMaxPrice.js';
+import { pushRequesterSecret } from '../utils/pushRequesterSecret.js';
 import {
   addressOrEnsOrAnySchema,
   positiveNumberSchema,
@@ -12,9 +15,6 @@ import {
   urlArraySchema,
 } from '../utils/validators.js';
 import { IExecConsumer, ProcessProtectedDataParams } from './types.js';
-import { WorkflowError } from '../utils/errors.js';
-import { fetchOrdersUnderMaxPrice } from '../utils/fetchOrdersUnderMaxPrice.js';
-import { pushRequesterSecret } from '../utils/pushRequesterSecret.js';
 
 export const processProtectedData = async ({
   iexec = throwIfMissing(),

--- a/src/dataProtector/revokeAllAccessObservable.ts
+++ b/src/dataProtector/revokeAllAccessObservable.ts
@@ -1,17 +1,17 @@
-import {
-  IExecConsumer,
-  RevokeAllAccessParams,
-  RevokeAllAccessMessage,
-} from './types.js';
 import { WorkflowError } from '../utils/errors.js';
+import { Observable, SafeObserver } from '../utils/reactive.js';
 import {
   addressOrEnsOrAnySchema,
   addressOrEnsSchema,
   throwIfMissing,
 } from '../utils/validators.js';
-import { Observable, SafeObserver } from '../utils/reactive.js';
 import { fetchGrantedAccess } from './fetchGrantedAccess.js';
 import { revokeOneAccess } from './revokeOneAccess.js';
+import {
+  IExecConsumer,
+  RevokeAllAccessParams,
+  RevokeAllAccessMessage,
+} from './types.js';
 
 export const revokeAllAccessObservable = ({
   iexec = throwIfMissing(),

--- a/src/dataProtector/revokeOneAccess.ts
+++ b/src/dataProtector/revokeOneAccess.ts
@@ -1,6 +1,6 @@
-import { IExecConsumer, GrantedAccess, RevokedAccess } from './types.js';
 import { WorkflowError } from '../utils/errors.js';
 import { grantedAccessSchema, throwIfMissing } from '../utils/validators.js';
+import { IExecConsumer, GrantedAccess, RevokedAccess } from './types.js';
 
 export const revokeOneAccess = async ({
   iexec = throwIfMissing(),

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,5 +1,5 @@
-import { filetypeinfo } from 'magic-bytes.js';
 import JSZip from 'jszip';
+import { filetypeinfo } from 'magic-bytes.js';
 import {
   DataObject,
   DataSchema,

--- a/src/utils/fetchOrdersUnderMaxPrice.ts
+++ b/src/utils/fetchOrdersUnderMaxPrice.ts
@@ -4,8 +4,8 @@ import {
   PublishedDatasetorder,
   PublishedWorkerpoolorder,
 } from 'iexec/IExecOrderbookModule';
-import { validateOrders } from './validators.js';
 import { DEFAULT_MAX_PRICE } from '../config/config.js';
+import { validateOrders } from './validators.js';
 
 export const fetchOrdersUnderMaxPrice = (
   datasetOrderbook: PaginableOrders<PublishedDatasetorder>,

--- a/src/utils/generateUniqueId.ts
+++ b/src/utils/generateUniqueId.ts
@@ -1,5 +1,5 @@
-import { randomBytes } from '@ethersproject/random';
 import { hexlify } from '@ethersproject/bytes';
+import { randomBytes } from '@ethersproject/random';
 
 export function generateSecureUniqueId(length: number): string {
   return hexlify(randomBytes(length));

--- a/src/utils/whitelist.ts
+++ b/src/utils/whitelist.ts
@@ -1,5 +1,5 @@
-import { IExec } from 'iexec';
 import { id } from 'ethers';
+import { IExec } from 'iexec';
 import {
   ADD_RESOURCE_SELECTOR,
   KEY_PURPOSE_SELECTOR,

--- a/tests/e2e/IExecDataProtector/constructor.test.ts
+++ b/tests/e2e/IExecDataProtector/constructor.test.ts
@@ -2,13 +2,13 @@
 // needed to access and assert IExecDataProtector's private properties
 import { describe, it, expect } from '@jest/globals';
 import { Wallet } from 'ethers';
-import { IExecDataProtector, getWeb3Provider } from '../../../src/index.js';
 import {
   DEFAULT_CONTRACT_ADDRESS,
   DEFAULT_IEXEC_IPFS_NODE,
   DEFAULT_IPFS_GATEWAY,
   DEFAULT_SUBGRAPH_URL,
 } from '../../../src/config/config.js';
+import { IExecDataProtector, getWeb3Provider } from '../../../src/index.js';
 
 describe('IExecDataProtector()', () => {
   it('should use default ipfs node url when ipfsNode is not provided', async () => {

--- a/tests/e2e/IExecDataProtector/fetchGrantedAccess.test.ts
+++ b/tests/e2e/IExecDataProtector/fetchGrantedAccess.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, expect } from '@jest/globals';
+import { HDNodeWallet, Wallet } from 'ethers';
 import { IExecDataProtector, getWeb3Provider } from '../../../src/index.js';
 import { ValidationError } from '../../../src/utils/errors.js';
-import { HDNodeWallet, Wallet } from 'ethers';
 import {
   MAX_EXPECTED_BLOCKTIME,
   deployRandomApp,

--- a/tests/e2e/IExecDataProtector/fetchProtectedData.test.ts
+++ b/tests/e2e/IExecDataProtector/fetchProtectedData.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, expect } from '@jest/globals';
+import { HDNodeWallet, Wallet } from 'ethers';
 import { IExecDataProtector, getWeb3Provider } from '../../../src/index.js';
 import { ValidationError } from '../../../src/utils/errors.js';
-import { HDNodeWallet, Wallet } from 'ethers';
 import { MAX_EXPECTED_BLOCKTIME } from '../../test-utils.js';
 
 describe('dataProtector.fetchProtectedData()', () => {

--- a/tests/e2e/IExecDataProtector/processProtectedData.test.ts
+++ b/tests/e2e/IExecDataProtector/processProtectedData.test.ts
@@ -1,10 +1,10 @@
 import { beforeAll, describe, it } from '@jest/globals';
+import { HDNodeWallet, Wallet } from 'ethers';
 import {
   IExecDataProtector,
   ProtectedDataWithSecretProps,
   getWeb3Provider,
 } from '../../../src/index.js';
-import { HDNodeWallet, Wallet } from 'ethers';
 import { MAX_EXPECTED_BLOCKTIME } from '../../test-utils.js';
 
 describe('dataProtector.processProtectedData()', () => {

--- a/tests/e2e/IExecDataProtector/protectData.test.ts
+++ b/tests/e2e/IExecDataProtector/protectData.test.ts
@@ -1,7 +1,7 @@
-import { beforeEach, describe, expect, it } from '@jest/globals';
-import { HDNodeWallet, Wallet } from 'ethers';
 import fsPromises from 'fs/promises';
 import path from 'path';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { HDNodeWallet, Wallet } from 'ethers';
 import { IExecDataProtector, getWeb3Provider } from '../../../src/index.js';
 import { ValidationError, WorkflowError } from '../../../src/utils/errors.js';
 import { MAX_EXPECTED_BLOCKTIME } from '../../test-utils.js';

--- a/tests/e2e/IExecDataProtector/protectDataObservable.test.ts
+++ b/tests/e2e/IExecDataProtector/protectDataObservable.test.ts
@@ -1,7 +1,7 @@
-import { beforeEach, describe, expect, it } from '@jest/globals';
-import { HDNodeWallet, Wallet } from 'ethers';
 import fsPromises from 'fs/promises';
 import path from 'path';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { HDNodeWallet, Wallet } from 'ethers';
 import { IExecDataProtector, getWeb3Provider } from '../../../src/index.js';
 import { ValidationError, WorkflowError } from '../../../src/utils/errors.js';
 import {

--- a/tests/e2e/IExecDataProtector/revokeAllAccessObservable.test.ts
+++ b/tests/e2e/IExecDataProtector/revokeAllAccessObservable.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeAll, beforeEach } from '@jest/globals';
 import { Wallet } from 'ethers';
-import { IExecDataProtector, getWeb3Provider } from '../../../src/index.js';
-import { ValidationError } from '../../../src/utils/errors.js';
 import {
   Address,
   ProtectedDataWithSecretProps,
 } from '../../../src/dataProtector/types.js';
+import { IExecDataProtector, getWeb3Provider } from '../../../src/index.js';
+import { ValidationError } from '../../../src/utils/errors.js';
 import {
   MAX_EXPECTED_BLOCKTIME,
   MAX_EXPECTED_MARKET_API_PURGE_TIME,

--- a/tests/e2e/IExecDataProtector/transferOwnership.test.ts
+++ b/tests/e2e/IExecDataProtector/transferOwnership.test.ts
@@ -5,8 +5,8 @@ import {
   ProtectedData,
   getWeb3Provider,
 } from '../../../src/index.js';
-import { MAX_EXPECTED_BLOCKTIME } from '../../test-utils.js';
 import { ValidationError } from '../../../src/utils/errors.js';
+import { MAX_EXPECTED_BLOCKTIME } from '../../test-utils.js';
 
 describe('dataProtector.transferOwnership()', () => {
   let dataProtector: IExecDataProtector;

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,7 +1,7 @@
 import { Wallet } from 'ethers';
-import { Observable } from '../src/utils/reactive.js';
 import { IExecAppModule, TeeFramework } from 'iexec';
 import { getWeb3Provider, Web3SignerProvider } from '../src/index.js';
+import { Observable } from '../src/utils/reactive.js';
 
 export const getRequiredFieldMessage = (field: string = 'this') =>
   `${field} is a required field`;

--- a/tests/unit/fetchGrantedAccess.test.ts
+++ b/tests/unit/fetchGrantedAccess.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { IExec } from 'iexec';
 import { Wallet } from 'ethers';
+import { IExec } from 'iexec';
 import { fetchGrantedAccess } from '../../src/dataProtector/fetchGrantedAccess.js';
 import { getWeb3Provider } from '../../src/index.js';
 

--- a/tests/unit/fetchOrdersUnderMaxPrice.test.ts
+++ b/tests/unit/fetchOrdersUnderMaxPrice.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { IExec } from 'iexec';
 import { Wallet } from 'ethers';
+import { IExec } from 'iexec';
+import { fetchOrdersUnderMaxPrice } from '../../src/utils/fetchOrdersUnderMaxPrice.js';
 import { getWeb3Provider } from '../../src/utils/getWeb3Provider.js';
 import {
   EMPTY_ORDER_BOOK,
@@ -9,7 +10,6 @@ import {
   MOCK_DATASET_ORDER,
   MOCK_WORKERPOOL_ORDER,
 } from '../test-utils.js';
-import { fetchOrdersUnderMaxPrice } from '../../src/utils/fetchOrdersUnderMaxPrice.js';
 
 describe('processProtectedData > fetchOrdersUnderMaxPrice', () => {
   const wallet = Wallet.createRandom();

--- a/tests/unit/processProtectedData.test.ts
+++ b/tests/unit/processProtectedData.test.ts
@@ -6,22 +6,22 @@ import {
   it,
   jest,
 } from '@jest/globals';
-import { IExec } from 'iexec';
 import { Wallet } from 'ethers';
+import { IExec } from 'iexec';
 import { processProtectedData } from '../../src/dataProtector/processProtectedData.js';
-import { getWeb3Provider } from '../../src/utils/getWeb3Provider.js';
 import {
   IExecDataProtector,
   ProtectedDataWithSecretProps,
 } from '../../src/index.js';
+import { WorkflowError } from '../../src/utils/errors.js';
+import { fetchOrdersUnderMaxPrice } from '../../src/utils/fetchOrdersUnderMaxPrice.js';
+import { getWeb3Provider } from '../../src/utils/getWeb3Provider.js';
 import {
   MAX_EXPECTED_BLOCKTIME,
   MOCK_APP_ORDER,
   MOCK_DATASET_ORDER,
   MOCK_WORKERPOOL_ORDER,
 } from '../test-utils.js';
-import { WorkflowError } from '../../src/utils/errors.js';
-import { fetchOrdersUnderMaxPrice } from '../../src/utils/fetchOrdersUnderMaxPrice.js';
 
 describe('processProtectedData', () => {
   const wallet = Wallet.createRandom();

--- a/tests/unit/utils/data.test.ts
+++ b/tests/unit/utils/data.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect, beforeAll, beforeEach } from '@jest/globals';
 import fsPromises from 'fs/promises';
 import path from 'path';
+import { describe, it, expect, beforeAll, beforeEach } from '@jest/globals';
+import JSZip from 'jszip';
+import { filetypeinfo } from 'magic-bytes.js';
+import { GraphQLResponse } from '../../../src/dataProtector/types.js';
 import {
   ensureDataObjectIsValid,
   ensureDataSchemaIsValid,
@@ -8,9 +11,6 @@ import {
   createZipFromObject,
   transformGraphQLResponse,
 } from '../../../src/utils/data.js';
-import { filetypeinfo } from 'magic-bytes.js';
-import JSZip from 'jszip';
-import { GraphQLResponse } from '../../../src/dataProtector/types.js';
 
 const uint8ArraysAreEqual = (a: Uint8Array, b: Uint8Array) => {
   if (a.byteLength !== b.byteLength) return false;


### PR DESCRIPTION
Have a predictable order for imports.
The default order is:
```
["builtin", "external", "parent", "sibling", "index"]
```

Example:
```
import fs from 'node:fs'; // builtin
import { Model } from 'mongoose'; // external
import { AppModule } from '../app.module'; // parent
import { DatabaseModule } from './database.module'; // sibling
```

Hopefully to reduce diffs in PRs 👍