### PR TITLE
deprecate old nightly version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -91,6 +91,14 @@ steps:
     commands:
       - npm run build
 
+  - name: authenticate
+    image: robertstettner/drone-npm-auth
+    settings:
+      username:
+        from_secret: npm_username
+      token:
+        from_secret: npm_token
+
   - name: deprecate-old-nightly-version
     image: node:18
     pull: always

--- a/.drone.yml
+++ b/.drone.yml
@@ -54,8 +54,8 @@ trigger:
     - promote
   target:
     - nightly
-  # branch:
-  #   - develop
+  branch:
+    - develop
 
 steps:
   - name: install

--- a/.drone.yml
+++ b/.drone.yml
@@ -54,8 +54,8 @@ trigger:
     - promote
   target:
     - nightly
-  branch:
-    - develop
+  # branch:
+  #   - develop
 
 steps:
   - name: install
@@ -90,6 +90,15 @@ steps:
     image: node:18
     commands:
       - npm run build
+
+  - name: deprecate-old-nightly-version
+    image: node:18
+    pull: always
+    commands:
+      - apt-get update && apt-get install -y jq
+      # fetches the latest nightly version of the @iexec/dataprotector package from npm registry
+      - PREVIOUS_NIGHTLY_VERSION=$(npm show @iexec/dataprotector versions --json | jq -r 'map(select(test("nightly"))) | .[-1]')
+      - if [ -n "$PREVIOUS_NIGHTLY_VERSION" ]; then npm deprecate @iexec/dataprotector@$PREVIOUS_NIGHTLY_VERSION "Deprecate $PREVIOUS_NIGHTLY_VERSION"; fi
 
   - name: set version nightly
     image: node:18


### PR DESCRIPTION
Dans cette PR j'ai ajouté des améliorations aux pipelines de drone pour faciliter la gestion des versions "nightly": 
- déclencher automatiquement à chaque publication "nightly" du SDK :  supprimer automatiquement la version "nightly" précédente pour maintenir une seule version "nightly" active sur le registre npm.