### PR TITLE
polish support for ArrayBuffer in data

### DIFF
--- a/src/dataProtector/types.ts
+++ b/src/dataProtector/types.ts
@@ -25,7 +25,12 @@ export type SubgraphConsumer = {
   graphQLClient: GraphQLClient;
 };
 
-export type DataScalarType = boolean | number | string | Uint8Array;
+export type DataScalarType =
+  | boolean
+  | number
+  | string
+  | Uint8Array
+  | ArrayBuffer;
 export interface DataObject
   extends Record<string, DataObject | DataScalarType> {}
 

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -69,6 +69,7 @@ export const ensureDataObjectIsValid = (data: DataObject) => {
     const typeOfValue = typeof value;
     if (
       value instanceof Uint8Array ||
+      value instanceof ArrayBuffer ||
       typeOfValue === 'boolean' ||
       typeOfValue === 'string' ||
       typeOfValue === 'number'

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -174,8 +174,14 @@ export const createZipFromObject = (obj: unknown): Promise<Uint8Array> => {
         content = value.toString();
       } else if (typeof value === 'boolean') {
         content = value ? new Uint8Array([1]) : new Uint8Array([0]);
-      } else {
+      } else if (
+        typeof value === 'string' ||
+        value instanceof Uint8Array ||
+        value instanceof ArrayBuffer
+      ) {
         content = value;
+      } else {
+        promises.push(Promise.reject(Error('Unexpected data format')));
       }
       promises.push(
         zip

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -11,4 +11,5 @@ class WorkflowError extends Error {
     }
   }
 }
+
 export { WorkflowError, ValidationError };

--- a/tests/unit/utils/data.test.ts
+++ b/tests/unit/utils/data.test.ts
@@ -338,6 +338,11 @@ describe('createZipFromObject()', () => {
         createZipFromObject({ ...data, invalid: Number.MAX_SAFE_INTEGER + 1 })
       ).rejects.toThrow(Error('Unsupported non safe integer number'));
     });
+    it('contains something that is not a boolean|number|string|Uint8Array|ArrayBuffer', async () => {
+      await expect(
+        createZipFromObject({ ...data, bigint: BigInt(1) })
+      ).rejects.toThrow(Error('Unexpected data format'));
+    });
   });
 });
 


### PR DESCRIPTION
- Small security check to avoid creating a zip with something not supported.
    NB: This should not be triggered in a normal flow where `ensureDataObjectIsValid` is called before `createZipFromObject`
- Stop diving inside ArrayBuffer object for data validation (ArrayBuffer is supported)
- Add ArrayBuffer in supported data type