### PR TITLE
add drone-consider for drone

### DIFF
--- a/.drone-consider
+++ b/.drone-consider
@@ -1,0 +1,1 @@
+.drone.yml


### PR DESCRIPTION
The drone plugin [drone-tree-config](https://github.com/bitsbeats/drone-tree-config) will be enabled for this repository in the next few days, a consider file `.drone-consider` listing the drone configuration files will be mandatory after the activation.