### PR TITLE
Feature/local stack tests

### DIFF
--- a/packages/sdk/.drone.yml
+++ b/packages/sdk/.drone.yml
@@ -7,6 +7,183 @@ trigger:
   event: push
 
 steps:
+  ##### START LOCAL STACK #####
+  - name: prepare local-stack-env
+    image: bash
+    commands:
+      - mkdir local-stack-env
+      - echo -n "https://bellecour.iex.ec" > local-stack-env/BELLECOUR_FORK_URL
+      # TODO get last block to configure BELLECOUR_FORK_BLOCK
+      - echo -n "26814000" > local-stack-env/BELLECOUR_FORK_BLOCK
+
+  - name: ipfs
+    image: ipfs/go-ipfs:v0.9.1
+    detach: true
+    expose:
+      - 8080
+      - 5001
+
+  - name: market-mongo
+    image: mongo:6.0.3
+    detach: true
+    expose:
+      - 27017
+
+  - name: market-redis
+    image: redis:7.0.7-alpine
+    detach: true
+    commands:
+      - redis-server --appendonly yes
+    expose:
+      - 6379
+
+  - name: result-proxy-mongo
+    image: library/mongo:4.2
+    detach: true
+    command:
+      - mongod --bind_ip_all --port 13202
+    expose:
+      - 13202
+
+  - name: graphnode-postgres
+    image: postgres:12
+    detach: true
+    commands:
+      - postgres -cshared_preload_libraries=pg_stat_statements
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: graphnode
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: graphnode-db
+
+  - name: bellecour-fork
+    detach: true
+    image: ghcr.io/foundry-rs/foundry:latest
+    pull: always
+    expose:
+      - 8545
+    commands:
+      - anvil --host 0.0.0.0 --port 8545 --block-time 1 --hardfork berlin --fork-url $(cat local-stack-env/BELLECOUR_FORK_URL) --fork-block-number $(cat local-stack-env/BELLECOUR_FORK_BLOCK) --chain-id 134 --gas-limit 6700000 --gas-price 0
+
+  - name: deps healthchecks
+    image: bash
+    commands:
+      # TODO bellecour-fork healthcheck
+      - echo "bellecour-fork ready"
+      # TODO ipfs healthcheck
+      - echo "ipfs ready"
+      # TODO market-mongo healthcheck
+      - echo "market-mongo ready"
+      # TODO market-redis healthcheck
+      - echo "market-redis ready"
+      # TODO result-proxy-mongo healthcheck
+      - echo "result-proxy-mongo ready"
+      # TODO graphnode-postgres healthcheck
+      - echo "graphnode-postgres ready"
+      - sleep 30
+
+  - name: sms
+    image: iexechub/iexec-sms:7.1.0
+    detach: true
+    environment:
+      TZ: Europe/Paris
+      IEXEC_SMS_BLOCKCHAIN_NODE_ADDRESS: http://bellecour-fork:8545
+      IEXEC_HUB_ADDRESS: '0x3eca1B216A7DF1C7689aEb259fFB83ADFB894E7f'
+      IEXEC_TEE_WORKER_PRE_COMPUTE_IMAGE: docker.io/iexechub/tee-worker-pre-compute:7.1.0-sconify-5.3.15-debug
+      IEXEC_TEE_WORKER_PRE_COMPUTE_FINGERPRINT: 9f0f782d6edc611baa23ca0978f555ee58ea70e092640c961e75c25e9e4b0f22
+      IEXEC_TEE_WORKER_PRE_COMPUTE_HEAP_SIZE_GB: 4
+      IEXEC_TEE_WORKER_POST_COMPUTE_IMAGE: docker.io/iexechub/tee-worker-post-compute:7.1.1-sconify-5.3.15-debug
+      IEXEC_TEE_WORKER_POST_COMPUTE_FINGERPRINT: face1376b97131e2dc75a556381d47a2e03bed9e1bc11e462471f99d1eefae50
+      IEXEC_TEE_WORKER_POST_COMPUTE_HEAP_SIZE_GB: 4
+      IEXEC_IGNORED_SGX_ADVISORIES: INTEL-SA-00161,INTEL-SA-00289,INTEL-SA-00334,INTEL-SA-00381,INTEL-SA-00389,INTEL-SA-00220,INTEL-SA-00270,INTEL-SA-00293,INTEL-SA-00320,INTEL-SA-00329,INTEL-SA-00477
+      IEXEC_SCONE_TOLERATED_INSECURE_OPTIONS: debug-mode,hyperthreading,outdated-tcb
+      IEXEC_SMS_DISPLAY_DEBUG_SESSION: 'true'
+      IEXEC_SCONE_CAS_HOST: foo
+      IEXEC_SMS_IMAGE_LAS_IMAGE: foo
+    expose:
+      - 13300
+
+  - name: market-watcher
+    image: iexechub/iexec-market-watcher:6.4
+    detach: true
+    environment:
+      CHAIN: BELLECOUR
+      ETH_WS_HOST: ws://bellecour-fork:8545
+      ETH_RPC_HOST: http://bellecour-fork:8545
+      MONGO_HOST: market-mongo
+      REDIS_HOST: market-redis
+    commands:
+      - export START_BLOCK=$(cat local-stack-env/BELLECOUR_FORK_BLOCK)
+      - npm start
+
+  - name: market-api
+    image: iexechub/iexec-market-api:6.4
+    detach: true
+    expose:
+      - 3000
+    environment:
+      CHAINS: BELLECOUR_FORK
+      BELLECOUR_FORK_ETH_RPC_HOST: http://bellecour-fork:8545
+      BELLECOUR_FORK_CHAIN_ID: 134
+      BELLECOUR_FORK_IS_NATIVE: 'true'
+      BELLECOUR_FORK_IEXEC_ADDRESS: '0x3eca1B216A7DF1C7689aEb259fFB83ADFB894E7f'
+      MONGO_HOST: market-mongo
+      REDIS_HOST: market-redis
+      RATE_LIMIT_MAX: 10000
+      RATE_LIMIT_PERIOD: 60000
+      MAX_OPEN_ORDERS_PER_WALLET: 1000
+
+  - name: result-proxy
+    image: iexechub/iexec-result-proxy:7.1.0
+    detach: true
+    environment:
+      IEXEC_PRIVATE_CHAIN_ADDRESS: http://bellecour-fork:8545
+      IEXEC_PUBLIC_CHAIN_ADDRESS: http://bellecour-fork:8545
+      IEXEC_HUB_ADDRESS: '0x3eca1B216A7DF1C7689aEb259fFB83ADFB894E7f'
+      MONGO_HOST: result-proxy-mongo
+      MONGO_PORT: 13202
+      IEXEC_IPFS_HOST: ipfs
+    expose:
+      - 13200
+
+  - name: graphnode
+    image: graphprotocol/graph-node:v0.27.0
+    detach: true
+    expose:
+      - 8000
+      - 8020
+    environment:
+      postgres_host: graphnode-postgres
+      postgres_port: 5432
+      postgres_user: graphnode
+      postgres_pass: password
+      postgres_db: graphnode-db
+      ipfs: ipfs:5001
+      ethereum: bellecour:http://bellecour-fork:8545
+    commands:
+      - export GRAPH_ETHEREUM_GENESIS_BLOCK_NUMBER=$(cat local-stack-env/BELLECOUR_FORK_BLOCK)
+      - start
+
+  - name: graphnode healthcheck
+    image: bash
+    commands:
+      # TODO
+      - sleep 10
+
+  - name: local subgraph deployment
+    image: node:18
+    environment:
+      GRAPHNODE_URL: http://graphnode:8020
+      IPFS_URL: http://ipfs:5001
+    commands:
+      - export START_BLOCK=$(cat local-stack-env/BELLECOUR_FORK_BLOCK)
+      - cd packages/subgraph
+      - npm ci
+      - npm run all
+
+  ### START LOCAL STACK END ###
+
   - name: only sdk package
     image: bash
     commands:

--- a/packages/sdk/.drone.yml
+++ b/packages/sdk/.drone.yml
@@ -40,7 +40,7 @@ steps:
   - name: result-proxy-mongo
     image: library/mongo:4.2
     detach: true
-    command:
+    commands:
       - mongod --bind_ip_all --port 13202
     expose:
       - 13202

--- a/packages/sdk/.drone.yml
+++ b/packages/sdk/.drone.yml
@@ -13,6 +13,15 @@ steps:
     commands:
       - node packages/sdk/tests/prepare-test-env.js
 
+  - name: bellecour-fork
+    detach: true
+    image: ghcr.io/foundry-rs/foundry:latest
+    pull: always
+    expose:
+      - 8545
+    commands:
+      - anvil --host 0.0.0.0 --port 8545 --block-time 1 --hardfork berlin --fork-url $(cat local-stack-env/BELLECOUR_FORK_URL) --fork-block-number $(cat local-stack-env/BELLECOUR_FORK_BLOCK) --chain-id 134 --gas-limit 6700000 --gas-price 0
+
   - name: ipfs
     image: ipfs/go-ipfs:v0.9.1
     detach: true
@@ -54,31 +63,31 @@ steps:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: graphnode-db
 
-  - name: bellecour-fork
+  - name: graphnode
+    image: graphprotocol/graph-node:v0.27.0
     detach: true
-    image: ghcr.io/foundry-rs/foundry:latest
-    pull: always
     expose:
-      - 8545
+      - 8000
+      - 8020
+    environment:
+      postgres_host: graphnode-postgres
+      postgres_port: 5432
+      postgres_user: graphnode
+      postgres_pass: password
+      postgres_db: graphnode-db
+      ipfs: ipfs:5001
+      ethereum: bellecour:http://bellecour-fork:8545
     commands:
-      - anvil --host 0.0.0.0 --port 8545 --block-time 1 --hardfork berlin --fork-url $(cat local-stack-env/BELLECOUR_FORK_URL) --fork-block-number $(cat local-stack-env/BELLECOUR_FORK_BLOCK) --chain-id 134 --gas-limit 6700000 --gas-price 0
-
-  - name: deps healthchecks
-    image: bash
-    commands:
-      # TODO bellecour-fork healthcheck
-      - echo "bellecour-fork ready"
-      # TODO ipfs healthcheck
-      - echo "ipfs ready"
-      # TODO market-mongo healthcheck
-      - echo "market-mongo ready"
-      # TODO market-redis healthcheck
-      - echo "market-redis ready"
-      # TODO result-proxy-mongo healthcheck
-      - echo "result-proxy-mongo ready"
-      # TODO graphnode-postgres healthcheck
-      - echo "graphnode-postgres ready"
-      - sleep 30
+      # bellecour-fork healthcheck
+      - while ! nc -z bellecour-fork 8545 ; do sleep 1 ; done && echo "bellecour-fork ready"
+      # ipfs healthcheck
+      - while ! nc -z ipfs 8080 ; do sleep 1 ; done && echo "ipfs gateway ready"
+      - while ! nc -z ipfs 5001 ; do sleep 1 ; done && echo "ipfs upload ready"
+      # graphnode-postgres healthcheck
+      - while ! nc -z graphnode-postgres 5432 ; do sleep 1 ; done && echo "graphnode-postgres ready"
+      # start
+      - export GRAPH_ETHEREUM_GENESIS_BLOCK_NUMBER=$(cat local-stack-env/BELLECOUR_FORK_BLOCK)
+      - start
 
   - name: sms
     image: iexechub/iexec-sms:7.1.0
@@ -100,6 +109,31 @@ steps:
       IEXEC_SMS_IMAGE_LAS_IMAGE: foo
     expose:
       - 13300
+    commands:
+      # bellecour-fork healthcheck
+      - sleep 30
+      # start
+      - java -jar /app/iexec-sms.jar
+
+  - name: result-proxy
+    image: iexechub/iexec-result-proxy:7.1.0
+    detach: true
+    environment:
+      IEXEC_PRIVATE_CHAIN_ADDRESS: http://bellecour-fork:8545
+      IEXEC_PUBLIC_CHAIN_ADDRESS: http://bellecour-fork:8545
+      IEXEC_HUB_ADDRESS: '0x3eca1B216A7DF1C7689aEb259fFB83ADFB894E7f'
+      MONGO_HOST: result-proxy-mongo
+      MONGO_PORT: 13202
+      IEXEC_IPFS_HOST: ipfs
+    expose:
+      - 13200
+    commands:
+      # bellecour-fork healthcheck
+      # result-proxy-mongo healthcheck
+      # ipfs healthcheck
+      - sleep 30
+      # start
+      - exec java -Djava.security.egd=file:/dev/./urandom -jar /iexec-result-proxy.jar
 
   - name: market-watcher
     image: iexechub/iexec-market-watcher:6.4
@@ -111,6 +145,13 @@ steps:
       MONGO_HOST: market-mongo
       REDIS_HOST: market-redis
     commands:
+      # bellecour-fork healthcheck
+      - while ! nc -z bellecour-fork 8545 ; do sleep 1 ; done && echo "bellecour-fork ready"
+      # market-mongo healthcheck
+      - while ! nc -z market-mongo 27017 ; do sleep 1 ; done && echo "market-mongo ready"
+      # market-redis healthcheck
+      - while ! nc -z market-redis 6379 ; do sleep 1 ; done && echo "market-redis ready"
+      # start
       - export START_BLOCK=$(cat local-stack-env/BELLECOUR_FORK_BLOCK)
       - cd /app
       - npm start
@@ -131,43 +172,17 @@ steps:
       RATE_LIMIT_MAX: 10000
       RATE_LIMIT_PERIOD: 60000
       MAX_OPEN_ORDERS_PER_WALLET: 1000
-
-  - name: result-proxy
-    image: iexechub/iexec-result-proxy:7.1.0
-    detach: true
-    environment:
-      IEXEC_PRIVATE_CHAIN_ADDRESS: http://bellecour-fork:8545
-      IEXEC_PUBLIC_CHAIN_ADDRESS: http://bellecour-fork:8545
-      IEXEC_HUB_ADDRESS: '0x3eca1B216A7DF1C7689aEb259fFB83ADFB894E7f'
-      MONGO_HOST: result-proxy-mongo
-      MONGO_PORT: 13202
-      IEXEC_IPFS_HOST: ipfs
-    expose:
-      - 13200
-
-  - name: graphnode
-    image: graphprotocol/graph-node:v0.27.0
-    detach: true
-    expose:
-      - 8000
-      - 8020
-    environment:
-      postgres_host: graphnode-postgres
-      postgres_port: 5432
-      postgres_user: graphnode
-      postgres_pass: password
-      postgres_db: graphnode-db
-      ipfs: ipfs:5001
-      ethereum: bellecour:http://bellecour-fork:8545
     commands:
-      - export GRAPH_ETHEREUM_GENESIS_BLOCK_NUMBER=$(cat local-stack-env/BELLECOUR_FORK_BLOCK)
-      - start
-
-  - name: graphnode healthcheck
-    image: bash
-    commands:
-      # TODO
-      - sleep 10
+      # bellecour-fork healthcheck
+      - while ! nc -z bellecour-fork 8545 ; do sleep 1 ; done && echo "bellecour-fork ready"
+      # market-mongo healthcheck
+      - while ! nc -z market-mongo 27017 ; do sleep 1 ; done && echo "market-mongo ready"
+      # market-redis healthcheck
+      - while ! nc -z market-redis 6379 ; do sleep 1 ; done && echo "market-redis ready"
+      # start
+      - export START_BLOCK=$(cat local-stack-env/BELLECOUR_FORK_BLOCK)
+      - cd /app
+      - npm start
 
   - name: local subgraph deployment
     image: node:18
@@ -175,10 +190,30 @@ steps:
       GRAPHNODE_URL: http://graphnode:8020
       IPFS_URL: http://ipfs:5001
     commands:
-      - export START_BLOCK=$(cat local-stack-env/BELLECOUR_FORK_BLOCK)
+      # install deps
       - cd packages/subgraph
       - npm ci
+      # ipfs healthcheck
+      - while ! curl http://ipfs:5001 > /dev/null 2>&1 ; do sleep 1 ; done && echo "ipfs ready"
+      # graphnode healthcheck
+      - while ! curl http://graphnode:8020 > /dev/null 2>&1 ; do sleep 1 ; done && echo "graphnode admin ready"
+      - export START_BLOCK=$(cat local-stack-env/BELLECOUR_FORK_BLOCK)
       - npm run all
+
+  - name: services healthcheck
+    image: bash
+    commands:
+      # bellecour-fork healthcheck
+      - while ! nc -z bellecour-fork 8545 ; do sleep 1 ; done && echo "bellecour-fork ready"
+      # ipfs healthcheck
+      - while ! nc -z ipfs 8080 ; do sleep 1 ; done && echo "ipfs gateway ready"
+      - while ! nc -z ipfs 5001 ; do sleep 1 ; done && echo "ipfs upload ready"
+      # market-api healthcheck
+      - while ! nc -z market-api 3000 ; do sleep 1 ; done && echo "market-api ready"
+      # sms healthcheck
+      - while ! nc -z sms 13300 ; do sleep 1 ; done && echo "sms ready"
+      # result-proxy healthcheck
+      - while ! nc -z result-proxy 13200 ; do sleep 1 ; done && echo "result-proxy ready"
 
   ### START LOCAL STACK END ###
 

--- a/packages/sdk/.drone.yml
+++ b/packages/sdk/.drone.yml
@@ -9,12 +9,9 @@ trigger:
 steps:
   ##### START LOCAL STACK #####
   - name: prepare local-stack-env
-    image: bash
+    image: node
     commands:
-      - mkdir local-stack-env
-      - echo -n "https://bellecour.iex.ec" > local-stack-env/BELLECOUR_FORK_URL
-      # TODO get last block to configure BELLECOUR_FORK_BLOCK
-      - echo -n "26814000" > local-stack-env/BELLECOUR_FORK_BLOCK
+      - node packages/sdk/tests/prepare-test-env.js
 
   - name: ipfs
     image: ipfs/go-ipfs:v0.9.1

--- a/packages/sdk/.drone.yml
+++ b/packages/sdk/.drone.yml
@@ -115,6 +115,7 @@ steps:
       REDIS_HOST: market-redis
     commands:
       - export START_BLOCK=$(cat local-stack-env/BELLECOUR_FORK_BLOCK)
+      - cd /app
       - npm start
 
   - name: market-api

--- a/packages/sdk/.drone.yml
+++ b/packages/sdk/.drone.yml
@@ -185,7 +185,7 @@ steps:
       - npm start
 
   - name: local subgraph deployment
-    image: node:18
+    image: node:18.19
     environment:
       GRAPHNODE_URL: http://graphnode:8020
       IPFS_URL: http://ipfs:5001

--- a/packages/sdk/.drone.yml
+++ b/packages/sdk/.drone.yml
@@ -49,7 +49,7 @@ steps:
     image: postgres:12
     detach: true
     commands:
-      - postgres -cshared_preload_libraries=pg_stat_statements
+      - docker-entrypoint.sh postgres -cshared_preload_libraries=pg_stat_statements
     expose:
       - 5432
     environment:

--- a/packages/sdk/.eslintignore
+++ b/packages/sdk/.eslintignore
@@ -2,3 +2,5 @@
 **/demo/
 **/dist/
 **/node_modules/
+
+tests/prepare-test-env.js

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Fixed a bug that allowed `"any"` to be passed as `protectedData` to `processProtectedData`
 - Fixed a bug that allowed `"any"` to be passed as `app` to `processProtectedData`
 - Fixed a bug that may cause the user to pay gas fees when creating a protected data
+- Fixed a bug that may cause incorrect requestorder max prices in `processProtectedData`
 - Changed URL validation to be more permissive
 
 ## [0.5.1] (2024-01-11)

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,9 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## NEXT
 
+### Added
+
+- Added `workerpool` option for `processProtectedData` to override the workerpool to use
+- Added a dockerized local stack for testing
+
 ### Changed
 
+- Run tests on a local stack forked from bellecour
 - Support ENS names for `owner` option of `fetchProtectedData`
+- Fixed a bug that allowed `"any"` to be passed as `protectedData` to `processProtectedData`
+- Fixed a bug that allowed `"any"` to be passed as `app` to `processProtectedData`
+- Fixed a bug that may cause the user to pay gas fees when creating a protected data
+- Changed URL validation to be more permissive
 
 ## [0.5.1] (2024-01-11)
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -21,7 +21,7 @@
     "format": "prettier --write \"(src|tests)/**/*.ts\"",
     "check-format": "prettier --check \"(src|tests)/**/*.ts|tests/**/*.ts\"",
     "stop-test-stack": "cd tests && docker compose down --remove-orphans",
-    "run-test-stack": "cd tests && npm run stop-test-stack && node prepare-test-env.js && docker compose up -d"
+    "start-test-stack": "cd tests && npm run stop-test-stack && node prepare-test-env.js && docker compose up -d"
   },
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,7 +19,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"(src|tests)/**/*.ts\"",
-    "check-format": "prettier --check \"(src|tests)/**/*.ts|tests/**/*.ts\""
+    "check-format": "prettier --check \"(src|tests)/**/*.ts|tests/**/*.ts\"",
+    "stop-test-stack": "cd tests && docker compose down --remove-orphans",
+    "run-test-stack": "cd tests && npm run stop-test-stack && node prepare-test-env.js && docker compose up -d"
   },
   "repository": {
     "type": "git",

--- a/packages/sdk/src/dataProtector/processProtectedData.ts
+++ b/packages/sdk/src/dataProtector/processProtectedData.ts
@@ -8,6 +8,7 @@ import { fetchOrdersUnderMaxPrice } from '../utils/fetchOrdersUnderMaxPrice.js';
 import { pushRequesterSecret } from '../utils/pushRequesterSecret.js';
 import {
   addressOrEnsOrAnySchema,
+  addressOrEnsSchema,
   positiveNumberSchema,
   secretsSchema,
   stringSchema,
@@ -24,14 +25,15 @@ export const processProtectedData = async ({
   args,
   inputFiles,
   secrets,
+  workerpool,
 }: IExecConsumer & ProcessProtectedDataParams): Promise<Taskid> => {
   try {
     const requester = await iexec.wallet.getAddress();
-    const vApp = addressOrEnsOrAnySchema()
+    const vApp = addressOrEnsSchema()
       .required()
       .label('authorizedApp')
       .validateSync(app);
-    const vProtectedData = addressOrEnsOrAnySchema()
+    const vProtectedData = addressOrEnsSchema()
       .required()
       .label('protectedData')
       .validateSync(protectedData);
@@ -43,6 +45,10 @@ export const processProtectedData = async ({
       .validateSync(inputFiles);
     const vArgs = stringSchema().label('args').validateSync(args);
     const vSecrets = secretsSchema().label('secrets').validateSync(secrets);
+    const vWorkerpool = addressOrEnsOrAnySchema()
+      .default(WORKERPOOL_ADDRESS)
+      .label('workerpool')
+      .validateSync(workerpool);
     const isIpfsStorageInitialized =
       await iexec.storage.checkStorageTokenExists(requester);
     if (!isIpfsStorageInitialized) {
@@ -54,6 +60,7 @@ export const processProtectedData = async ({
       vProtectedData,
       {
         app: vApp,
+        workerpool: vWorkerpool,
         requester,
       }
     );
@@ -62,10 +69,10 @@ export const processProtectedData = async ({
       requester,
       minTag: SCONE_TAG,
       maxTag: SCONE_TAG,
-      workerpool: WORKERPOOL_ADDRESS,
+      workerpool: vWorkerpool,
     });
     const workerpoolOrderbook = await iexec.orderbook.fetchWorkerpoolOrderbook({
-      workerpool: WORKERPOOL_ADDRESS,
+      workerpool: vWorkerpool,
       app: vApp,
       dataset: vProtectedData,
       minTag: SCONE_TAG,
@@ -88,7 +95,7 @@ export const processProtectedData = async ({
       appmaxprice: vMaxPrice,
       workerpoolmaxprice: vMaxPrice,
       tag: SCONE_TAG,
-      workerpool: WORKERPOOL_ADDRESS,
+      workerpool: underMaxPriceOrders.workerpoolorder.workerpool,
       params: {
         iexec_input_files: vInputFiles,
         iexec_developer_logger: true,

--- a/packages/sdk/src/dataProtector/processProtectedData.ts
+++ b/packages/sdk/src/dataProtector/processProtectedData.ts
@@ -92,8 +92,9 @@ export const processProtectedData = async ({
       app: vApp,
       category: underMaxPriceOrders.workerpoolorder.category,
       dataset: vProtectedData,
-      appmaxprice: vMaxPrice,
-      workerpoolmaxprice: vMaxPrice,
+      appmaxprice: underMaxPriceOrders.apporder.appprice,
+      datasetmaxprice: underMaxPriceOrders.datasetorder.datasetprice,
+      workerpoolmaxprice: underMaxPriceOrders.workerpoolorder.workerpoolprice,
       tag: SCONE_TAG,
       workerpool: underMaxPriceOrders.workerpoolorder.workerpool,
       params: {

--- a/packages/sdk/src/dataProtector/protectDataObservable.ts
+++ b/packages/sdk/src/dataProtector/protectDataObservable.ts
@@ -120,7 +120,7 @@ export const protectDataObservable = ({
           cid,
         });
 
-        const { provider, signer } =
+        const { provider, signer, txOptions } =
           await iexec.config.resolveContractsClient();
 
         const contract = new ethers.Contract(contractAddress, ABI, provider);
@@ -140,7 +140,8 @@ export const protectDataObservable = ({
             vName,
             JSON.stringify(schema),
             multiaddrBytes,
-            checksum
+            checksum,
+            txOptions
           )
           .then((tx) => tx.wait())
           .catch((e: Error) => {

--- a/packages/sdk/src/dataProtector/types.ts
+++ b/packages/sdk/src/dataProtector/types.ts
@@ -111,6 +111,11 @@ export type ProcessProtectedDataParams = {
    * It is represented as a mapping of numerical identifiers to corresponding secrets.
    */
   secrets?: Record<number, string>;
+
+  /**
+   * The workerpool to use for the application's execution. (default iExec production workerpool)
+   */
+  workerpool?: AddressOrENS | 'any';
 };
 
 type ProtectDataDataExtractedMessage = {

--- a/packages/sdk/src/utils/validators.ts
+++ b/packages/sdk/src/utils/validators.ts
@@ -17,7 +17,8 @@ const isZeroStringTest = (value: string) => value === '0';
 export const stringSchema = () =>
   string().strict().typeError('${path} should be a string');
 
-export const urlSchema = () => string().url('${path} should be a url');
+export const urlSchema = () =>
+  string().matches(/^http[s]?:\/\//, '${path} should be a url');
 
 export const addressSchema = () =>
   string()

--- a/packages/sdk/tests/.env
+++ b/packages/sdk/tests/.env
@@ -1,0 +1,6 @@
+#### ENV FOR TEST STACK COMPOSE INCLUDE IN GIT ####
+
+# blockchain node to use as the reference for the local fork
+BELLECOUR_FORK_URL=https://bellecour.iex.ec
+# block number to fork from
+BELLECOUR_FORK_BLOCK=26814000

--- a/packages/sdk/tests/.env
+++ b/packages/sdk/tests/.env
@@ -1,6 +1,0 @@
-#### ENV FOR TEST STACK COMPOSE INCLUDE IN GIT ####
-
-# blockchain node to use as the reference for the local fork
-BELLECOUR_FORK_URL=https://bellecour.iex.ec
-# block number to fork from
-BELLECOUR_FORK_BLOCK=26814000

--- a/packages/sdk/tests/docker-compose.yml
+++ b/packages/sdk/tests/docker-compose.yml
@@ -140,7 +140,7 @@ services:
       market-mongo:
         condition: service_started
 
-  postgres:
+  graphnode-postgres:
     image: postgres:12
     restart: unless-stopped
     command:
@@ -175,7 +175,7 @@ services:
       # # metrics
       - 8040:8040
     environment:
-      postgres_host: postgres
+      postgres_host: graphnode-postgres
       postgres_port: 5432
       postgres_user: graphnode
       postgres_pass: password
@@ -186,7 +186,7 @@ services:
     depends_on:
       bellecour-fork:
         condition: service_healthy
-      postgres:
+      graphnode-postgres:
         condition: service_healthy
       ipfs:
         condition: service_started

--- a/packages/sdk/tests/docker-compose.yml
+++ b/packages/sdk/tests/docker-compose.yml
@@ -1,0 +1,214 @@
+version: '3.9'
+
+services:
+  bellecour-fork:
+    restart: 'no'
+    image: ghcr.io/foundry-rs/foundry:latest
+    entrypoint: anvil
+    command: '--host 0.0.0.0 --port 8545 --block-time 1 --hardfork berlin --fork-url $BELLECOUR_FORK_URL --fork-block-number $BELLECOUR_FORK_BLOCK --chain-id 134 --gas-limit 6700000 --gas-price 0'
+    expose:
+      - 8545
+    ports:
+      - 8545:8545
+    healthcheck:
+      test: wget http://localhost:8545/ -q --post-data "{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}"
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  sms:
+    image: iexechub/iexec-sms:7.1.0
+    restart: unless-stopped
+    environment:
+      TZ: Europe/Paris
+      IEXEC_SMS_BLOCKCHAIN_NODE_ADDRESS: http://bellecour-fork:8545
+      IEXEC_HUB_ADDRESS: '0x3eca1B216A7DF1C7689aEb259fFB83ADFB894E7f'
+      IEXEC_TEE_WORKER_PRE_COMPUTE_IMAGE: docker.io/iexechub/tee-worker-pre-compute:7.1.0-sconify-5.3.15-debug
+      IEXEC_TEE_WORKER_PRE_COMPUTE_FINGERPRINT: 9f0f782d6edc611baa23ca0978f555ee58ea70e092640c961e75c25e9e4b0f22
+      IEXEC_TEE_WORKER_PRE_COMPUTE_HEAP_SIZE_GB: 4
+      IEXEC_TEE_WORKER_POST_COMPUTE_IMAGE: docker.io/iexechub/tee-worker-post-compute:7.1.1-sconify-5.3.15-debug
+      IEXEC_TEE_WORKER_POST_COMPUTE_FINGERPRINT: face1376b97131e2dc75a556381d47a2e03bed9e1bc11e462471f99d1eefae50
+      IEXEC_TEE_WORKER_POST_COMPUTE_HEAP_SIZE_GB: 4
+      IEXEC_IGNORED_SGX_ADVISORIES: INTEL-SA-00161,INTEL-SA-00289,INTEL-SA-00334,INTEL-SA-00381,INTEL-SA-00389,INTEL-SA-00220,INTEL-SA-00270,INTEL-SA-00293,INTEL-SA-00320,INTEL-SA-00329,INTEL-SA-00477
+      IEXEC_SCONE_TOLERATED_INSECURE_OPTIONS: debug-mode,hyperthreading,outdated-tcb
+      IEXEC_SMS_DISPLAY_DEBUG_SESSION: 'true'
+      IEXEC_SCONE_CAS_HOST: foo
+      IEXEC_SMS_IMAGE_LAS_IMAGE: foo
+    ports:
+      - 13300:13300
+    depends_on:
+      bellecour-fork:
+        condition: service_healthy
+
+  result-proxy:
+    image: iexechub/iexec-result-proxy:7.1.0
+    restart: unless-stopped
+    environment:
+      IEXEC_PRIVATE_CHAIN_ADDRESS: http://bellecour-fork:8545
+      IEXEC_PUBLIC_CHAIN_ADDRESS: http://bellecour-fork:8545
+      IEXEC_HUB_ADDRESS: '0x3eca1B216A7DF1C7689aEb259fFB83ADFB894E7f'
+      MONGO_HOST: result-proxy-mongo
+      MONGO_PORT: 13202
+      IEXEC_IPFS_HOST: ipfs
+    ports:
+      - 13200:13200
+    depends_on:
+      bellecour-fork:
+        condition: service_healthy
+      result-proxy-mongo:
+        condition: service_started
+      ipfs:
+        condition: service_started
+
+  result-proxy-mongo:
+    restart: unless-stopped
+    image: library/mongo:4.2
+    entrypoint: '/bin/bash'
+    command: -c "mongod --bind_ip_all --port 13202"
+    expose:
+      - 13202
+
+  ipfs:
+    restart: unless-stopped
+    image: ipfs/go-ipfs:v0.9.1
+    expose:
+      - 8080
+      - 5001
+    ports:
+      - 8080:8080
+      - 5001:5001
+
+  market-mongo:
+    image: mongo:latest
+    restart: unless-stopped
+    expose:
+      - 27017
+    ports:
+      - 27017:27017
+
+  market-redis:
+    image: redis:alpine
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+    expose:
+      - 6379
+    ports:
+      - 6379:6379
+
+  market-watcher:
+    image: iexechub/iexec-market-watcher:6.4
+    restart: unless-stopped
+    environment:
+      CHAIN: BELLECOUR
+      START_BLOCK: $BELLECOUR_FORK_BLOCK
+      ETH_WS_HOST: ws://bellecour-fork:8545
+      ETH_RPC_HOST: http://bellecour-fork:8545
+      MONGO_HOST: market-mongo
+      REDIS_HOST: market-redis
+    depends_on:
+      bellecour-fork:
+        condition: service_healthy
+      market-redis:
+        condition: service_started
+      market-mongo:
+        condition: service_started
+
+  market-api:
+    image: iexechub/iexec-market-api:6.4
+    restart: unless-stopped
+    ports:
+      - 3000:3000
+    expose:
+      - 3000
+    environment:
+      CHAINS: BELLECOUR_FORK
+      BELLECOUR_FORK_ETH_RPC_HOST: http://bellecour-fork:8545
+      BELLECOUR_FORK_CHAIN_ID: 134
+      BELLECOUR_FORK_IS_NATIVE: 'true'
+      BELLECOUR_FORK_IEXEC_ADDRESS: '0x3eca1B216A7DF1C7689aEb259fFB83ADFB894E7f'
+      MONGO_HOST: market-mongo
+      REDIS_HOST: market-redis
+      RATE_LIMIT_MAX: 10000
+      RATE_LIMIT_PERIOD: 60000
+      MAX_OPEN_ORDERS_PER_WALLET: 1000
+    depends_on:
+      bellecour-fork:
+        condition: service_healthy
+      market-redis:
+        condition: service_started
+      market-mongo:
+        condition: service_started
+
+  postgres:
+    image: postgres:12
+    restart: unless-stopped
+    command:
+      - 'postgres'
+      - '-cshared_preload_libraries=pg_stat_statements'
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: graphnode
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: graphnode-db
+    healthcheck:
+      test: pg_isready -U graphnode -d graphnode-db
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  graphnode:
+    image: graphprotocol/graph-node:v0.27.0
+    restart: unless-stopped
+    expose:
+      - 8000
+      - 8020
+    ports:
+      # GraphQL HTTP
+      - 8000:8000
+      # GraphQL WS
+      # - 8001:8001
+      # admin RPC
+      - 8020:8020
+      # # metrics
+      - 8040:8040
+    environment:
+      postgres_host: postgres
+      postgres_port: 5432
+      postgres_user: graphnode
+      postgres_pass: password
+      postgres_db: graphnode-db
+      ipfs: ipfs:5001
+      ethereum: bellecour:http://bellecour-fork:8545
+      GRAPH_ETHEREUM_GENESIS_BLOCK_NUMBER: $BELLECOUR_FORK_BLOCK
+    depends_on:
+      bellecour-fork:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      ipfs:
+        condition: service_started
+    healthcheck:
+      test: netcat -w 1 0.0.0.0 8020
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  dataprotector-subgraph-deployer:
+    image: dataprotector-subgraph-deployer
+    restart: 'on-failure'
+    build:
+      context: ../../subgraph
+      dockerfile: deployer.Dockerfile
+    depends_on:
+      graphnode:
+        condition: service_healthy
+      ipfs:
+        condition: service_started
+    environment:
+      START_BLOCK: $BELLECOUR_FORK_BLOCK
+      GRAPHNODE_URL: http://graphnode:8020
+      IPFS_URL: http://ipfs:5001

--- a/packages/sdk/tests/docker-compose.yml
+++ b/packages/sdk/tests/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - 5001:5001
 
   market-mongo:
-    image: mongo:latest
+    image: mongo:6.0.3
     restart: unless-stopped
     expose:
       - 27017
@@ -88,7 +88,7 @@ services:
       - 27017:27017
 
   market-redis:
-    image: redis:alpine
+    image: redis:7.0.7-alpine
     restart: unless-stopped
     command: redis-server --appendonly yes
     expose:

--- a/packages/sdk/tests/docker-compose.yml
+++ b/packages/sdk/tests/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - 8545:8545
     healthcheck:
-      test: wget http://localhost:8545/ -q --post-data "{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}"
+      test: wget http://0.0.0.0:8545/ -q --post-data "{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}"
       interval: 10s
       timeout: 5s
       retries: 3

--- a/packages/sdk/tests/e2e/fetchGrantedAccess.test.ts
+++ b/packages/sdk/tests/e2e/fetchGrantedAccess.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, beforeEach, expect } from '@jest/globals';
 import { HDNodeWallet, Wallet } from 'ethers';
-import { IExecDataProtector, getWeb3Provider } from '../../src/index.js';
+import { IExecDataProtector } from '../../src/index.js';
 import { ValidationError } from '../../src/utils/errors.js';
 import {
   MAX_EXPECTED_BLOCKTIME,
   MAX_EXPECTED_WEB2_SERVICES_TIME,
   deployRandomApp,
+  getTestConfig,
   getRandomAddress,
 } from '../test-utils.js';
 
@@ -14,7 +15,7 @@ describe('dataProtector.fetchGrantedAccess()', () => {
   let wallet: HDNodeWallet;
   beforeEach(async () => {
     wallet = Wallet.createRandom();
-    dataProtector = new IExecDataProtector(getWeb3Provider(wallet.privateKey));
+    dataProtector = new IExecDataProtector(...getTestConfig(wallet.privateKey));
   });
 
   it(

--- a/packages/sdk/tests/e2e/fetchProtectedData.test.ts
+++ b/packages/sdk/tests/e2e/fetchProtectedData.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { HDNodeWallet, Wallet } from 'ethers';
-import { IExecDataProtector, getWeb3Provider } from '../../src/index.js';
+import { IExecDataProtector } from '../../src/index.js';
 import { ValidationError } from '../../src/utils/errors.js';
-import { MAX_EXPECTED_WEB2_SERVICES_TIME } from '../test-utils.js';
+import {
+  MAX_EXPECTED_WEB2_SERVICES_TIME,
+  getTestConfig,
+} from '../test-utils.js';
 
 describe('dataProtector.fetchProtectedData()', () => {
   let dataProtector: IExecDataProtector;
@@ -10,7 +13,7 @@ describe('dataProtector.fetchProtectedData()', () => {
 
   beforeEach(async () => {
     wallet = Wallet.createRandom();
-    dataProtector = new IExecDataProtector(getWeb3Provider(wallet.privateKey));
+    dataProtector = new IExecDataProtector(...getTestConfig(wallet.privateKey));
   });
 
   it(

--- a/packages/sdk/tests/e2e/grantAccess.test.ts
+++ b/packages/sdk/tests/e2e/grantAccess.test.ts
@@ -1,10 +1,11 @@
 import { beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import { HDNodeWallet, Wallet } from 'ethers';
 import { ProtectedDataWithSecretProps } from '../../src/dataProtector/types.js';
-import { IExecDataProtector, getWeb3Provider } from '../../src/index.js';
+import { IExecDataProtector } from '../../src/index.js';
 import { ValidationError, WorkflowError } from '../../src/utils/errors.js';
 import {
   deployRandomApp,
+  getTestConfig,
   getRandomAddress,
   getRequiredFieldMessage,
   MAX_EXPECTED_BLOCKTIME,
@@ -24,7 +25,7 @@ describe('dataProtector.grantAccess()', () => {
 
   beforeAll(async () => {
     wallet = Wallet.createRandom();
-    dataProtector = new IExecDataProtector(getWeb3Provider(wallet.privateKey));
+    dataProtector = new IExecDataProtector(...getTestConfig(wallet.privateKey));
     const results = await Promise.all([
       dataProtector.protectData({
         data: { doNotUse: 'test' },

--- a/packages/sdk/tests/e2e/processProtectedData.test.ts
+++ b/packages/sdk/tests/e2e/processProtectedData.test.ts
@@ -1,29 +1,76 @@
 import { beforeAll, describe, expect, it } from '@jest/globals';
 import { HDNodeWallet, Wallet } from 'ethers';
+import { IExec } from 'iexec';
 import {
   IExecDataProtector,
   ProtectedDataWithSecretProps,
-  getWeb3Provider,
 } from '../../src/index.js';
 import {
   MAX_EXPECTED_BLOCKTIME,
   MAX_EXPECTED_WEB2_SERVICES_TIME,
+  getTestConfig,
+  getTestIExecOption,
+  getTestWeb3SignerProvider,
 } from '../test-utils.js';
 
 describe('dataProtector.processProtectedData()', () => {
   let dataProtector: IExecDataProtector;
   let wallet: HDNodeWallet;
   let protectedData: ProtectedDataWithSecretProps;
+  let app: string;
   beforeAll(async () => {
     wallet = Wallet.createRandom();
-    dataProtector = new IExecDataProtector(getWeb3Provider(wallet.privateKey));
+    dataProtector = new IExecDataProtector(...getTestConfig(wallet.privateKey));
+    const ethProvider = getTestWeb3SignerProvider(
+      Wallet.createRandom().privateKey
+    );
+    const iexecOptions = getTestIExecOption();
+    const resourceProvider = new IExec({ ethProvider }, iexecOptions);
+    const { address: appAddress } = await resourceProvider.app.deployApp({
+      owner: ethProvider.address,
+      name: 'test app',
+      type: 'DOCKER',
+      multiaddr: 'foo',
+      mrenclave: {
+        framework: 'SCONE',
+        entrypoint: 'node app.js',
+        heapSize: 123,
+        version: 'v',
+        fingerprint: 'foo',
+      },
+      checksum:
+        '0x00f51494d7a42a3c1c43464d9f09e06b2a99968e3b978f6cd11ab3410b7bcd14',
+    });
+    await resourceProvider.order
+      .createApporder({
+        app: appAddress,
+        tag: ['tee', 'scone'],
+      })
+      .then(resourceProvider.order.signApporder)
+      .then(resourceProvider.order.publishApporder);
+    app = appAddress;
+
+    const { address: workerpoolAddress } =
+      await resourceProvider.workerpool.deployWorkerpool({
+        owner: ethProvider.address,
+        description: 'test pool',
+      });
+    await resourceProvider.order
+      .createWorkerpoolorder({
+        workerpool: workerpoolAddress,
+        category: 0,
+        tag: ['tee', 'scone'],
+      })
+      .then(resourceProvider.order.signWorkerpoolorder)
+      .then(resourceProvider.order.publishWorkerpoolorder);
+    app = appAddress;
 
     protectedData = await dataProtector.protectData({
       data: { email: 'example@example.com' },
       name: 'test do not use',
     });
     await dataProtector.grantAccess({
-      authorizedApp: '0x4605e8af487897faaef16f0709391ef1be828591',
+      authorizedApp: appAddress,
       protectedData: protectedData.address,
       authorizedUser: wallet.address,
     });
@@ -33,12 +80,13 @@ describe('dataProtector.processProtectedData()', () => {
     async () => {
       const taskId = await dataProtector.processProtectedData({
         protectedData: protectedData.address,
-        app: '0x4605e8af487897faaef16f0709391ef1be828591',
+        app: app,
         secrets: {
           1: 'ProcessProtectedData test subject',
           2: 'email content for test processData',
         },
         args: '_args_test_process_data_',
+        workerpool: 'any',
       });
       expect(taskId).toBeDefined();
     },

--- a/packages/sdk/tests/e2e/protectData.test.ts
+++ b/packages/sdk/tests/e2e/protectData.test.ts
@@ -7,6 +7,7 @@ import { ValidationError, WorkflowError } from '../../src/utils/errors.js';
 import {
   MAX_EXPECTED_BLOCKTIME,
   MAX_EXPECTED_WEB2_SERVICES_TIME,
+  getTestConfig,
 } from '../test-utils.js';
 
 describe('dataProtector.protectData()', () => {
@@ -14,7 +15,7 @@ describe('dataProtector.protectData()', () => {
   let wallet: HDNodeWallet;
   beforeEach(async () => {
     wallet = Wallet.createRandom();
-    dataProtector = new IExecDataProtector(getWeb3Provider(wallet.privateKey));
+    dataProtector = new IExecDataProtector(...getTestConfig(wallet.privateKey));
   });
 
   it(

--- a/packages/sdk/tests/e2e/protectDataObservable.test.ts
+++ b/packages/sdk/tests/e2e/protectDataObservable.test.ts
@@ -7,6 +7,7 @@ import { ValidationError, WorkflowError } from '../../src/utils/errors.js';
 import {
   MAX_EXPECTED_BLOCKTIME,
   MAX_EXPECTED_WEB2_SERVICES_TIME,
+  getTestConfig,
   runObservableSubscribe,
 } from '../test-utils.js';
 
@@ -15,7 +16,7 @@ describe('dataProtector.protectDataObservable()', () => {
   let wallet: HDNodeWallet;
   beforeEach(async () => {
     wallet = Wallet.createRandom();
-    dataProtector = new IExecDataProtector(getWeb3Provider(wallet.privateKey));
+    dataProtector = new IExecDataProtector(...getTestConfig(wallet.privateKey));
   });
 
   it(

--- a/packages/sdk/tests/e2e/revokeAllAccessObservable.test.ts
+++ b/packages/sdk/tests/e2e/revokeAllAccessObservable.test.ts
@@ -4,13 +4,14 @@ import {
   Address,
   ProtectedDataWithSecretProps,
 } from '../../src/dataProtector/types.js';
-import { IExecDataProtector, getWeb3Provider } from '../../src/index.js';
+import { IExecDataProtector } from '../../src/index.js';
 import { ValidationError } from '../../src/utils/errors.js';
 import {
   MAX_EXPECTED_BLOCKTIME,
   MAX_EXPECTED_MARKET_API_PURGE_TIME,
   MAX_EXPECTED_WEB2_SERVICES_TIME,
   deployRandomApp,
+  getTestConfig,
   getRandomAddress,
   getRequiredFieldMessage,
   runObservableSubscribe,
@@ -20,7 +21,7 @@ import {
 describe('dataProtector.revokeAllAccessObservable()', () => {
   const wallet = Wallet.createRandom();
   const dataProtector = new IExecDataProtector(
-    getWeb3Provider(wallet.privateKey)
+    ...getTestConfig(wallet.privateKey)
   );
 
   it(

--- a/packages/sdk/tests/e2e/revokeOneAccess.test.ts
+++ b/packages/sdk/tests/e2e/revokeOneAccess.test.ts
@@ -1,12 +1,13 @@
 import { beforeAll, describe, expect, it } from '@jest/globals';
 import { HDNodeWallet, Wallet } from 'ethers';
 import { ProtectedDataWithSecretProps } from '../../src/dataProtector/types.js';
-import { IExecDataProtector, getWeb3Provider } from '../../src/index.js';
+import { IExecDataProtector } from '../../src/index.js';
 import { ValidationError } from '../../src/utils/errors.js';
 import {
   MAX_EXPECTED_BLOCKTIME,
   MAX_EXPECTED_WEB2_SERVICES_TIME,
   deployRandomApp,
+  getTestConfig,
   getRandomAddress,
 } from '../test-utils.js';
 
@@ -17,7 +18,7 @@ describe('dataProtector.revokeOneAccess()', () => {
   let sconeAppAddress: string;
   beforeAll(async () => {
     wallet = Wallet.createRandom();
-    dataProtector = new IExecDataProtector(getWeb3Provider(wallet.privateKey));
+    dataProtector = new IExecDataProtector(...getTestConfig(wallet.privateKey));
     const result = await Promise.all([
       dataProtector.protectData({
         data: { doNotUse: 'test' },

--- a/packages/sdk/tests/e2e/transferOwnership.test.ts
+++ b/packages/sdk/tests/e2e/transferOwnership.test.ts
@@ -1,14 +1,11 @@
 import { beforeAll, describe, expect, it } from '@jest/globals';
 import { HDNodeWallet, Wallet } from 'ethers';
-import {
-  IExecDataProtector,
-  ProtectedData,
-  getWeb3Provider,
-} from '../../src/index.js';
+import { IExecDataProtector, ProtectedData } from '../../src/index.js';
 import { ValidationError } from '../../src/utils/errors.js';
 import {
   MAX_EXPECTED_BLOCKTIME,
   MAX_EXPECTED_WEB2_SERVICES_TIME,
+  getTestConfig,
 } from '../test-utils.js';
 
 describe('dataProtector.transferOwnership()', () => {
@@ -18,7 +15,7 @@ describe('dataProtector.transferOwnership()', () => {
 
   beforeAll(async () => {
     wallet = Wallet.createRandom();
-    dataProtector = new IExecDataProtector(getWeb3Provider(wallet.privateKey));
+    dataProtector = new IExecDataProtector(...getTestConfig(wallet.privateKey));
     protectedData = await dataProtector.protectData({
       data: { doNotUse: 'test' },
     });

--- a/packages/sdk/tests/prepare-test-env.js
+++ b/packages/sdk/tests/prepare-test-env.js
@@ -31,13 +31,13 @@ fetch(forkUrl, {
       writeFileSync(
         '.env',
         `############ THIS FILE IS GENERATED ############
-  # run "node prepare-test-env.js" to regenerate #
-  ################################################
-  
-  # blockchain node to use as the reference for the local fork
-  BELLECOUR_FORK_URL=${forkUrl}
-  # block number to fork from
-  BELLECOUR_FORK_BLOCK=${forkBlockNumber}`
+# run "node prepare-test-env.js" to regenerate #
+################################################
+
+# blockchain node to use as the reference for the local fork
+BELLECOUR_FORK_URL=${forkUrl}
+# block number to fork from
+BELLECOUR_FORK_BLOCK=${forkBlockNumber}`
       );
     }
   })

--- a/packages/sdk/tests/prepare-test-env.js
+++ b/packages/sdk/tests/prepare-test-env.js
@@ -1,0 +1,46 @@
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+const forkUrl = process.env.BELLECOUR_FORK_URL || 'https://bellecour.iex.ec';
+
+fetch(forkUrl, {
+  method: 'POST',
+  body: JSON.stringify({
+    jsonrpc: 2.0,
+    method: 'eth_blockNumber',
+    params: [],
+    id: 1,
+  }),
+})
+  .then((res) => res.json())
+  .then((jsonRes) => {
+    const forkBlockNumber = parseInt(jsonRes.result.substring(2), 16);
+    if (process.env.DRONE) {
+      const LOCAL_STACK_ENV_DIR = 'local-stack-env';
+      console.log(
+        `Creating ${LOCAL_STACK_ENV_DIR} directory for drone test-stack`
+      );
+      mkdirSync(LOCAL_STACK_ENV_DIR, { recursive: true });
+      writeFileSync(join(LOCAL_STACK_ENV_DIR, 'BELLECOUR_FORK_URL'), forkUrl);
+      writeFileSync(
+        join(LOCAL_STACK_ENV_DIR, 'BELLECOUR_FORK_BLOCK'),
+        `${forkBlockNumber}`
+      );
+    } else {
+      console.log('Creating .env file for docker-compose test-stack');
+      writeFileSync(
+        '.env',
+        `############ THIS FILE IS GENERATED ############
+  # run "node prepare-test-env.js" to regenerate #
+  ################################################
+  
+  # blockchain node to use as the reference for the local fork
+  BELLECOUR_FORK_URL=${forkUrl}
+  # block number to fork from
+  BELLECOUR_FORK_BLOCK=${forkBlockNumber}`
+      );
+    }
+  })
+  .catch((e) => {
+    throw Error(`Failed to get current block number from ${forkUrl}: ${e}`);
+  });

--- a/packages/sdk/tests/test-utils.ts
+++ b/packages/sdk/tests/test-utils.ts
@@ -1,7 +1,45 @@
 import { Wallet } from 'ethers';
-import { IExecAppModule, TeeFramework } from 'iexec';
-import { getWeb3Provider, Web3SignerProvider } from '../src/index.js';
+import { IExecAppModule, TeeFramework, utils } from 'iexec';
+import {
+  DataProtectorConfigOptions,
+  Web3SignerProvider,
+} from '../src/index.js';
 import { Observable } from '../src/utils/reactive.js';
+
+export const getTestWeb3SignerProvider = (
+  privateKey: string
+): Web3SignerProvider =>
+  utils.getSignerFromPrivateKey(
+    process.env.DRONE ? 'http://bellecour-fork:8545' : 'http://localhost:8545',
+    privateKey
+  );
+
+export const getTestIExecOption = () => ({
+  smsURL: process.env.DRONE ? 'http://sms:13300' : 'http://localhost:13300',
+  resultProxyURL: process.env.DRONE
+    ? 'http://result-proxy:13200'
+    : 'http://localhost:13200',
+  iexecGatewayURL: process.env.DRONE
+    ? 'http://market-api:3000'
+    : 'http://localhost:3000',
+});
+
+export const getTestConfig = (
+  privateKey: string
+): [Web3SignerProvider, DataProtectorConfigOptions] => {
+  const ethProvider = getTestWeb3SignerProvider(privateKey);
+  const options = {
+    iexecOptions: getTestIExecOption(),
+    ipfsGateway: process.env.DRONE
+      ? 'http://ipfs:8080'
+      : 'http://localhost:8080',
+    ipfsNode: process.env.DRONE ? 'http://ipfs:5001' : 'http://localhost:5001',
+    subgraphUrl: process.env.DRONE
+      ? 'http://graphnode:8000/subgraphs/name/DataProtector'
+      : 'http://localhost:8000/subgraphs/name/DataProtector',
+  };
+  return [ethProvider, options];
+};
 
 export const getRequiredFieldMessage = (field: string = 'this') =>
   `${field} is a required field`;
@@ -15,7 +53,8 @@ export const deployRandomApp = async (
   } = {}
 ) => {
   const ethProvider =
-    options.ethProvider || getWeb3Provider(Wallet.createRandom().privateKey);
+    options.ethProvider ||
+    getTestWeb3SignerProvider(Wallet.createRandom().privateKey);
   const iexecAppModule = new IExecAppModule({ ethProvider });
   const { address } = await iexecAppModule.deployApp({
     owner: ethProvider.address,

--- a/packages/subgraph/.dockerignore
+++ b/packages/subgraph/.dockerignore
@@ -1,0 +1,5 @@
+build
+generated
+node_modules
+.drone.yml
+subgraph.yaml

--- a/packages/subgraph/deployer.Dockerfile
+++ b/packages/subgraph/deployer.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18.19
 
 COPY . .
 

--- a/packages/subgraph/deployer.Dockerfile
+++ b/packages/subgraph/deployer.Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+
+COPY . .
+
+RUN npm ci
+
+ENTRYPOINT [ "npm", "run", "all" ]

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -5,11 +5,11 @@
   "scripts": {
     "codegen": "./generate-manifest.sh && graph codegen",
     "build": "./generate-manifest.sh && graph build",
-    "deploy": "./generate-manifest.sh && graph deploy --node https://api.thegraph.com/deploy/ DataProtector",
-    "create-local": "graph create --node http://localhost:8020/ DataProtector",
-    "remove-local": "graph remove --node http://localhost:8020/ DataProtector",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 DataProtector",
-    "all": "rm -r generated && rm -r build && npm run codegen && npm run build && npm run create-local && npm run deploy-local",
+    "create-local": "graph create --node ${GRAPHNODE_URL:-http://localhost:8020} DataProtector",
+    "remove-local": "graph remove --node ${GRAPHNODE_URL:-http://localhost:8020} DataProtector",
+    "deploy-local": "graph deploy --node ${GRAPHNODE_URL:-http://localhost:8020} --ipfs ${IPFS_URL:-http://localhost:5001} DataProtector --version-label ${VERSION_LABEL:-dev}",
+    "clean": "rm -rf generated && rm -rf build",
+    "all": "npm run clean && npm run codegen && npm run build && npm run create-local && npm run deploy-local",
     "test": "graph test",
     "coverage": "graph test -- -c"
   },

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -12,7 +12,6 @@ type ProtectedData @entity {
   schema: [SchemaEntry!]!
   owner: Account!
   name: String!
-  collection: Collection
   multiaddr: Bytes!
   checksum: Bytes!
   creationTimestamp: BigInt!
@@ -23,37 +22,4 @@ type ProtectedData @entity {
 type Account @entity {
   id: ID!
   datasets: [ProtectedData!]! @derivedFrom(field: "owner")
-}
-
-type Collection @entity {
-  id: Bytes!
-  owner: Bytes!
-  protectedDatas: [ProtectedData!] @derivedFrom(field: "collection")
-  subscriptions: [Subscription!]
-  subscriptionsParams: SubscriptionsParams
-  creationTimestamp: BigInt!
-  blockNumber: BigInt!
-  transactionHash: Bytes!
-}
-
-type SubscriptionsParams @entity {
-  id: Bytes!
-  duration: BigInt!
-  price: BigInt!
-}
-
-type Subscription @entity {
-  id: Bytes!
-  owner: Account!
-  endDate: BigInt!
-  creationTimestamp: BigInt!
-  blockNumber: BigInt!
-  transactionHash: Bytes!
-}
-
-type DealId @entity(immutable: true) {
-  id: Bytes!
-  creationTimestamp: BigInt!
-  blockNumber: BigInt!
-  transactionHash: Bytes!
 }


### PR DESCRIPTION
# Setup a local stack for tests

- [x] local test stack
  - [x] healthchecks
  - [x] start/stop script for the stack
- [x] CI test stack
  - [x] healthchecks
- [x] use local stack in tests

## Stack:

- blockchain
  - `bellecour-fork`
- core stack
  - `market-api` & `market-watcher`
  - `sms`
  - `result-proxy`
- dataprotector components 
  - `graphnode` with Dataprotector subgraph
  - `ipfs`
- ...and services deps (mutualized when possible)

The stack is configured by the `prepare-test-env.js` script to get the current block of the bellecour node to fork from.

## Usage:

### Local:

Before running tests locally, you must configure and start the local test stack by running

```sh
npm run start-test-stack
```
You will get a local stack running in docker.

Run your tests as usual
```sh
npm run tests
```

When finished you can teardown the local test stack
```sh
npm run stop-test-stack
```

If you need to refresh the stack (basically if the bellecour-fork restart, it will lose the history and components will be desynced), run the `start-test-stack` once again, this will teardown any existing stack and recreate a new one based on the current blockchain state.

### CI:

Do the same things as local but in a way we can do it in drone.