### PR TITLE
Re-allow boolean type

### DIFF
--- a/packages/sdk/src/lib/types/commonTypes.ts
+++ b/packages/sdk/src/lib/types/commonTypes.ts
@@ -90,7 +90,10 @@ export type MimeType =
   | 'video/mpeg'
   | 'video/x-msvideo';
 
-export type ScalarType = 'bool' | 'i128' | 'f64' | 'string';
+// A new serialisation logic was introduced in v2
+// 'boolean' was used before this new borsh serialisation
+// 'bool' is the new type
+export type ScalarType = 'boolean' | 'bool' | 'i128' | 'f64' | 'string';
 
 export type DataSchemaEntryType = ScalarType | MimeType;
 

--- a/packages/sdk/src/utils/data.ts
+++ b/packages/sdk/src/utils/data.ts
@@ -11,7 +11,16 @@ import {
 
 const ALLOWED_KEY_NAMES_REGEXP = /^[a-zA-Z0-9\-_]*$/;
 
-const SUPPORTED_TYPES: ScalarType[] = ['bool', 'i128', 'f64', 'string'];
+// A new serialisation logic was introduced in v2
+// 'boolean' was used before this new borsh serialisation
+// 'bool' is the new type
+const SUPPORTED_TYPES: ScalarType[] = [
+  'boolean',
+  'bool',
+  'i128',
+  'f64',
+  'string',
+];
 
 const MIN_I128 = BigInt('-170141183460469231731687303715884105728');
 const MAX_I128 = BigInt('170141183460469231731687303715884105728');


### PR DESCRIPTION
In `getProtectedData()`, we still need to be able to get older protected data that have been created with a type of `boolean`.