### PR TITLE
Avoid useless rebuild of subgraph-deployer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# this context is used to build the subgraph deployer (packages/subgraph/deployer.Dockerfile)
+# ignore everything
+*
+# but subgraph deps
+!/environments/
+!/packages/subgraph/
+/packages/subgraph/generated/
+/packages/subgraph/build/
+/packages/subgraph/subgraph.yaml
+/packages/subgraph/.drone.yml

--- a/packages/subgraph/.dockerignore
+++ b/packages/subgraph/.dockerignore
@@ -1,5 +1,0 @@
-build
-generated
-node_modules
-.drone.yml
-subgraph.yaml


### PR DESCRIPTION
Reduce the subgraph-deployer build context to avoid rebuilding the image when nothing related to the subgraph change

Benefits:
- faster first build due to reduced docker context
- reuse image from cache when nothing is changed in `environments` or `package/subgraph`