### PR TITLE
Release/sdk v2.0.0 beta.4

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-
-## [Next]
+## [2.0.0-beta.4] (2024-06-18)
 
 ### Added
 
 - Add new parameter `maxPrice` to `consumeProtectedData()` to define the maximum desired workerpool order price. Dataset and App max prices are managed by the sharing smart contract.
+
+### Changed
+
+- `getCollectionSubscriptions()`: Fix possible error when fetching subscriptions
 
 ## [2.0.0-beta.3] (2024-06-07)
 

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iexec/dataprotector",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iexec/dataprotector",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iexec/dataprotector",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "This product enables users to confidentially store data–such as mail address, documents, personal information ...",
   "type": "module",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
# [2.0.0-beta.4] (2024-06-18)

## Added
Add new parameter `maxPrice` to `consumeProtectedData()` to define the maximum desired workerpool order price. Dataset and App max prices are managed by the sharing smart contract.

## Changed
`getCollectionSubscriptions()`: Fix possible error when fetching subscriptions