### PR TITLE
Feature/approve and call payable methods

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## NEXT
+
+### Changed
+
+- Use `approveAndCall` staked RLC (iExec account) for payable methods `buyProtectedData`, `rentProtectedData`, `subscribeToCollection` when the allowance is insufficient (approve and payment are made in the same transaction).
+- Better error message when the account balance is insufficient to perform an action.
+
 ## [2.0.0-beta.4] (2024-06-18)
 
 ### Added

--- a/packages/sdk/abis/sharing/interfaces/IExecPocoDelegate.sol/IExecPocoDelegate.json
+++ b/packages/sdk/abis/sharing/interfaces/IExecPocoDelegate.sol/IExecPocoDelegate.json
@@ -3,6 +3,30 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "spender",
         "type": "address"
       },

--- a/packages/sdk/src/lib/dataProtectorSharing/addToCollection.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/addToCollection.ts
@@ -15,7 +15,7 @@ import {
   SuccessWithTransactionHash,
 } from '../types/index.js';
 import { IExecConsumer } from '../types/internalTypes.js';
-import { approveCollectionContract } from './smartContract/approveCollectionContract.js';
+import { approveProtectedDataForCollectionContract } from './smartContract/approveProtectedDataForCollectionContract.js';
 import { getAppWhitelistRegistryContract } from './smartContract/getAddOnlyAppWhitelistRegistryContract.js';
 import { getSharingContract } from './smartContract/getSharingContract.js';
 import {
@@ -77,7 +77,7 @@ export const addToCollection = async ({
     title: 'APPROVE_COLLECTION_CONTRACT',
     isDone: false,
   });
-  const approveTx = await approveCollectionContract({
+  const approveTx = await approveProtectedDataForCollectionContract({
     iexec,
     protectedData: vProtectedData,
     sharingContractAddress,

--- a/packages/sdk/src/lib/dataProtectorSharing/buyProtectedData.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/buyProtectedData.ts
@@ -84,18 +84,16 @@ export async function buyProtectedData({
   });
 
   try {
-    let tx: ContractTransactionResponse;
-
-    const buyProtectedDataCallParams: [AddressLike, AddressLike, BigNumberish] =
-      [vProtectedData, userAddress, vPrice];
     const { txOptions } = await iexec.config.resolveContractsClient();
 
+    let tx: ContractTransactionResponse;
+    const buyProtectedDataCallParams: [AddressLike, AddressLike, BigNumberish] =
+      [vProtectedData, userAddress, vPrice];
     if (accountDetails.sharingContractAllowance >= BigInt(vPrice)) {
       tx = await sharingContract.buyProtectedData(
         ...buyProtectedDataCallParams,
         txOptions
       );
-      await tx.wait();
     } else {
       const callData = sharingContract.interface.encodeFunctionData(
         'buyProtectedData',
@@ -107,8 +105,8 @@ export async function buyProtectedData({
         callData,
         txOptions
       );
-      await tx.wait();
     }
+    await tx.wait();
 
     if (vAddToCollectionId) {
       await onlyCollectionOperator({

--- a/packages/sdk/src/lib/dataProtectorSharing/buyProtectedData.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/buyProtectedData.ts
@@ -12,7 +12,7 @@ import {
   SuccessWithTransactionHash,
 } from '../types/index.js';
 import { IExecConsumer } from '../types/internalTypes.js';
-import { approveCollectionContract } from './smartContract/approveCollectionContract.js';
+import { approveProtectedDataForCollectionContract } from './smartContract/approveProtectedDataForCollectionContract.js';
 import { getSharingContract } from './smartContract/getSharingContract.js';
 import {
   onlyCollectionOperator,
@@ -88,7 +88,7 @@ export async function buyProtectedData({
       );
       await tx.wait();
 
-      await approveCollectionContract({
+      await approveProtectedDataForCollectionContract({
         iexec,
         protectedData: vProtectedData,
         sharingContractAddress,

--- a/packages/sdk/src/lib/dataProtectorSharing/consumeProtectedData.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/consumeProtectedData.ts
@@ -151,6 +151,7 @@ export const consumeProtectedData = async ({
     let tx;
     let transactionReceipt;
     try {
+      // TODO: when non free workerpoolorders is supported add approveAndCall (see implementation of buyProtectedData/rentProtectedData/subscribeToCollection)
       tx = await sharingContract.consumeProtectedData(
         vProtectedData,
         workerpoolOrder,

--- a/packages/sdk/src/lib/dataProtectorSharing/smartContract/approveProtectedDataForCollectionContract.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/smartContract/approveProtectedDataForCollectionContract.ts
@@ -1,8 +1,9 @@
-import { ContractTransactionResponse, ethers } from 'ethers';
+import { ethers } from 'ethers';
+import type { ContractTransactionResponse } from 'ethers';
 import { ErrorWithData } from '../../../utils/errors.js';
 import { throwIfMissing } from '../../../utils/validators.js';
 import type { Address } from '../../types/index.js';
-import { IExecConsumer } from '../../types/internalTypes.js';
+import type { IExecConsumer } from '../../types/internalTypes.js';
 import { getPocoDatasetRegistryContract } from './getPocoRegistryContract.js';
 
 export async function approveProtectedDataForCollectionContract({

--- a/packages/sdk/src/lib/dataProtectorSharing/smartContract/approveProtectedDataForCollectionContract.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/smartContract/approveProtectedDataForCollectionContract.ts
@@ -5,7 +5,7 @@ import type { Address } from '../../types/index.js';
 import { IExecConsumer } from '../../types/internalTypes.js';
 import { getPocoDatasetRegistryContract } from './getPocoRegistryContract.js';
 
-export async function approveCollectionContract({
+export async function approveProtectedDataForCollectionContract({
   iexec = throwIfMissing(),
   protectedData,
   sharingContractAddress,

--- a/packages/sdk/src/lib/dataProtectorSharing/smartContract/getAddOnlyAppWhitelistContract.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/smartContract/getAddOnlyAppWhitelistContract.ts
@@ -1,11 +1,11 @@
 import { Contract } from 'ethers';
-import { IExec } from 'iexec';
+import type { IExecModule } from 'iexec';
 import { ABI } from '../../../../generated/abis/sharing/registry/AddOnlyAppWhitelist.sol/AddOnlyAppWhitelist.js';
-import { AddOnlyAppWhitelist } from '../../../../generated/typechain/sharing/registry/AddOnlyAppWhitelist.js';
-import { Address } from '../../types/commonTypes.js';
+import type { AddOnlyAppWhitelist } from '../../../../generated/typechain/sharing/registry/AddOnlyAppWhitelist.js';
+import type { Address } from '../../types/commonTypes.js';
 
 export async function getAppWhitelistContract(
-  iexec: IExec,
+  iexec: IExecModule,
   addOnlyAppWhitelist: Address
 ): Promise<AddOnlyAppWhitelist> {
   const { signer } = await iexec.config.resolveContractsClient();

--- a/packages/sdk/src/lib/dataProtectorSharing/smartContract/getAddOnlyAppWhitelistRegistryContract.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/smartContract/getAddOnlyAppWhitelistRegistryContract.ts
@@ -1,12 +1,12 @@
 import { Contract } from 'ethers';
-import { IExec } from 'iexec';
+import type { IExecModule } from 'iexec';
 import { ABI } from '../../../../generated/abis/sharing/registry/AddOnlyAppWhitelistRegistry.sol/AddOnlyAppWhitelistRegistry.js';
-import { AddOnlyAppWhitelistRegistry } from '../../../../generated/typechain/sharing/registry/AddOnlyAppWhitelistRegistry.js';
-import { Address } from '../../types/commonTypes.js';
+import type { AddOnlyAppWhitelistRegistry } from '../../../../generated/typechain/sharing/registry/AddOnlyAppWhitelistRegistry.js';
+import type { Address } from '../../types/commonTypes.js';
 import { getSharingContract } from './getSharingContract.js';
 
 export async function getAppWhitelistRegistryContract(
-  iexec: IExec,
+  iexec: IExecModule,
   sharingContractAddress: Address
 ): Promise<AddOnlyAppWhitelistRegistry> {
   const { signer } = await iexec.config.resolveContractsClient();

--- a/packages/sdk/src/lib/dataProtectorSharing/smartContract/getPocoContract.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/smartContract/getPocoContract.ts
@@ -1,0 +1,9 @@
+import type { IExecModule } from 'iexec';
+import type { IExecPocoDelegate } from '../../../../generated/typechain/sharing/interfaces/IExecPocoDelegate.js';
+
+export async function getPocoContract(
+  iexec: IExecModule
+): Promise<IExecPocoDelegate> {
+  const client = await iexec.config.resolveContractsClient();
+  return client.getIExecContract() as unknown as IExecPocoDelegate;
+}

--- a/packages/sdk/src/lib/dataProtectorSharing/smartContract/getPocoRegistryContract.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/smartContract/getPocoRegistryContract.ts
@@ -1,14 +1,14 @@
 import { Contract } from 'ethers';
-import type { IExec } from 'iexec';
+import type { IExecModule } from 'iexec';
 import { ABI } from '../../../../generated/abis/sharing/interfaces/IRegistry.sol/IRegistry.js';
-import { IRegistry } from '../../../../generated/typechain/sharing/interfaces/IRegistry.js';
+import type { IRegistry } from '../../../../generated/typechain/sharing/interfaces/IRegistry.js';
 import {
   POCO_APP_REGISTRY_CONTRACT_ADDRESS,
   POCO_DATASET_REGISTRY_CONTRACT_ADDRESS,
 } from '../../../config/config.js';
 
 export async function getPocoDatasetRegistryContract(
-  iexec: IExec
+  iexec: IExecModule
 ): Promise<IRegistry> {
   const { signer } = await iexec.config.resolveContractsClient();
   return new Contract(POCO_DATASET_REGISTRY_CONTRACT_ADDRESS, ABI).connect(
@@ -17,7 +17,7 @@ export async function getPocoDatasetRegistryContract(
 }
 
 export async function getPocoAppRegistryContract(
-  iexec: IExec
+  iexec: IExecModule
 ): Promise<IRegistry> {
   const { signer } = await iexec.config.resolveContractsClient();
   return new Contract(POCO_APP_REGISTRY_CONTRACT_ADDRESS, ABI).connect(

--- a/packages/sdk/src/lib/dataProtectorSharing/smartContract/getSharingContract.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/smartContract/getSharingContract.ts
@@ -1,11 +1,11 @@
 import { Contract } from 'ethers';
-import { IExec } from 'iexec';
+import type { IExecModule } from 'iexec';
 import { ABI } from '../../../../generated/abis/sharing/DataProtectorSharing.sol/DataProtectorSharing.js';
-import { DataProtectorSharing } from '../../../../generated/typechain/sharing/DataProtectorSharing.js';
+import type { DataProtectorSharing } from '../../../../generated/typechain/sharing/DataProtectorSharing.js';
 import { Address } from '../../types/commonTypes.js';
 
 export async function getSharingContract(
-  iexec: IExec,
+  iexec: IExecModule,
   sharingContractAddress: Address
 ): Promise<DataProtectorSharing> {
   const { signer } = await iexec.config.resolveContractsClient();

--- a/packages/sdk/src/lib/dataProtectorSharing/smartContract/pocoContract.reads.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/smartContract/pocoContract.reads.ts
@@ -1,0 +1,45 @@
+import type { IExecPocoDelegate } from '../../../../generated/typechain/sharing/interfaces/IExecPocoDelegate.js';
+import type { Address } from '../../types/index.js';
+import type { AccountDetails } from '../../types/pocoTypes.js';
+
+const getAccountAllowance = async ({
+  pocoContract,
+  owner,
+  spender,
+}: {
+  pocoContract: IExecPocoDelegate;
+  owner: Address;
+  spender: Address;
+}) => {
+  return pocoContract.allowance(owner, spender);
+};
+
+const getAccountBalance = async ({
+  pocoContract,
+  owner,
+}: {
+  pocoContract: IExecPocoDelegate;
+  owner: Address;
+}) => {
+  return pocoContract.balanceOf(owner);
+};
+
+export const getAccountDetails = async ({
+  pocoContract,
+  userAddress,
+  sharingContractAddress,
+}: {
+  pocoContract: IExecPocoDelegate;
+  userAddress: Address;
+  sharingContractAddress: Address;
+}): Promise<AccountDetails> => {
+  const [balance, sharingContractAllowance] = await Promise.all([
+    getAccountBalance({ pocoContract, owner: userAddress }),
+    getAccountAllowance({
+      pocoContract,
+      owner: userAddress,
+      spender: sharingContractAddress,
+    }),
+  ]);
+  return { balance, sharingContractAllowance };
+};

--- a/packages/sdk/src/lib/dataProtectorSharing/smartContract/preflightChecks.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/smartContract/preflightChecks.ts
@@ -1,6 +1,5 @@
 import { ethers, getBigInt } from 'ethers';
 import type { DataProtectorSharing } from '../../../../generated/typechain/sharing/DataProtectorSharing.js';
-import type { IExecPocoDelegate } from '../../../../generated/typechain/sharing/interfaces/IExecPocoDelegate.js';
 import type { IRegistry } from '../../../../generated/typechain/sharing/interfaces/IRegistry.js';
 import type { AddOnlyAppWhitelist } from '../../../../generated/typechain/sharing/registry/AddOnlyAppWhitelist.js';
 import type { AddOnlyAppWhitelistRegistry } from '../../../../generated/typechain/sharing/registry/AddOnlyAppWhitelistRegistry.js';
@@ -381,20 +380,15 @@ export const onlyAppOwnedBySharingContract = async ({
 
 // ---------------------Account checks------------------------------------
 
-export const onlyAccountWithMinimumBalance = async ({
-  pocoContract,
-  address,
+export const onlyAccountWithMinimumBalance = ({
+  accountDetails,
   minimumBalance,
 }: {
-  pocoContract: IExecPocoDelegate;
-  address: Address;
+  accountDetails: { balance: bigint };
   minimumBalance: ethers.BigNumberish;
 }) => {
   const requiredBalance = BigInt(minimumBalance);
-  if (requiredBalance > BigInt(0)) {
-    const balance = await pocoContract.balanceOf(address);
-    if (balance < requiredBalance) {
-      throw new Error('Account balance is insufficient.');
-    }
+  if (accountDetails.balance < requiredBalance) {
+    throw new Error('Account balance is insufficient.');
   }
 };

--- a/packages/sdk/src/lib/dataProtectorSharing/smartContract/preflightChecks.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/smartContract/preflightChecks.ts
@@ -1,8 +1,9 @@
-import { getBigInt } from 'ethers';
-import { DataProtectorSharing } from '../../../../generated/typechain/sharing/DataProtectorSharing.js';
-import { IRegistry } from '../../../../generated/typechain/sharing/interfaces/IRegistry.js';
-import { AddOnlyAppWhitelist } from '../../../../generated/typechain/sharing/registry/AddOnlyAppWhitelist.js';
-import { AddOnlyAppWhitelistRegistry } from '../../../../generated/typechain/sharing/registry/AddOnlyAppWhitelistRegistry.js';
+import { ethers, getBigInt } from 'ethers';
+import type { DataProtectorSharing } from '../../../../generated/typechain/sharing/DataProtectorSharing.js';
+import type { IExecPocoDelegate } from '../../../../generated/typechain/sharing/interfaces/IExecPocoDelegate.js';
+import type { IRegistry } from '../../../../generated/typechain/sharing/interfaces/IRegistry.js';
+import type { AddOnlyAppWhitelist } from '../../../../generated/typechain/sharing/registry/AddOnlyAppWhitelist.js';
+import type { AddOnlyAppWhitelistRegistry } from '../../../../generated/typechain/sharing/registry/AddOnlyAppWhitelistRegistry.js';
 import { ErrorWithData } from '../../../utils/errors.js';
 import type {
   Address,
@@ -375,5 +376,25 @@ export const onlyAppOwnedBySharingContract = async ({
     });
   if (appOwner.toLowerCase() !== sharingContractAddress.toLowerCase()) {
     throw new Error('This app is not owned by the sharing contract.');
+  }
+};
+
+// ---------------------Account checks------------------------------------
+
+export const onlyAccountWithMinimumBalance = async ({
+  pocoContract,
+  address,
+  minimumBalance,
+}: {
+  pocoContract: IExecPocoDelegate;
+  address: Address;
+  minimumBalance: ethers.BigNumberish;
+}) => {
+  const requiredBalance = BigInt(minimumBalance);
+  if (requiredBalance > BigInt(0)) {
+    const balance = await pocoContract.balanceOf(address);
+    if (balance < requiredBalance) {
+      throw new Error('Account balance is insufficient.');
+    }
   }
 };

--- a/packages/sdk/src/lib/dataProtectorSharing/smartContract/sharingContract.reads.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/smartContract/sharingContract.reads.ts
@@ -1,5 +1,5 @@
-import { DataProtectorSharing } from '../../../../generated/typechain/sharing/DataProtectorSharing.js';
-import {
+import type { DataProtectorSharing } from '../../../../generated/typechain/sharing/DataProtectorSharing.js';
+import type {
   Address,
   Collection,
   ProtectedDataDetails,

--- a/packages/sdk/src/lib/dataProtectorSharing/subscribeToCollection.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/subscribeToCollection.ts
@@ -1,3 +1,4 @@
+import { BigNumberish, ContractTransactionResponse } from 'ethers';
 import { WorkflowError } from '../../utils/errors.js';
 import {
   positiveNumberSchema,
@@ -10,8 +11,11 @@ import {
   SuccessWithTransactionHash,
 } from '../types/index.js';
 import { IExecConsumer } from '../types/internalTypes.js';
+import { getPocoContract } from './smartContract/getPocoContract.js';
 import { getSharingContract } from './smartContract/getSharingContract.js';
+import { getAccountDetails } from './smartContract/pocoContract.reads.js';
 import {
+  onlyAccountWithMinimumBalance,
   onlyCollectionAvailableForSubscription,
   onlyValidSubscriptionParams,
 } from './smartContract/preflightChecks.js';
@@ -39,16 +43,26 @@ export const subscribeToCollection = async ({
     .label('price')
     .validateSync(price);
 
-  const sharingContract = await getSharingContract(
-    iexec,
-    sharingContractAddress
-  );
+  let userAddress = await iexec.wallet.getAddress();
+  userAddress = userAddress.toLowerCase();
+
+  const [sharingContract, pocoContract] = await Promise.all([
+    getSharingContract(iexec, sharingContractAddress),
+    getPocoContract(iexec),
+  ]);
 
   //---------- Smart Contract Call ----------
-  const collectionDetails = await getCollectionDetails({
-    sharingContract,
-    collectionId: vCollectionId,
-  });
+  const [collectionDetails, accountDetails] = await Promise.all([
+    getCollectionDetails({
+      sharingContract,
+      collectionId: vCollectionId,
+    }),
+    getAccountDetails({
+      pocoContract,
+      userAddress,
+      sharingContractAddress,
+    }),
+  ]);
 
   //---------- Pre flight check ----------
   onlyCollectionAvailableForSubscription(collectionDetails);
@@ -56,15 +70,41 @@ export const subscribeToCollection = async ({
     { price, duration },
     collectionDetails.subscriptionParams
   );
+  onlyAccountWithMinimumBalance({
+    accountDetails,
+    minimumBalance: vPrice,
+  });
   // TODO Check if the user is not already subscribed to the collection
 
   try {
     const { txOptions } = await iexec.config.resolveContractsClient();
-    const tx = await sharingContract.subscribeToCollection(
-      vCollectionId,
-      { duration: vDuration, price: vPrice },
-      txOptions
-    );
+
+    let tx: ContractTransactionResponse;
+    const subscribeToCollectionCallParams: [
+      BigNumberish,
+      {
+        price: BigNumberish;
+        duration: BigNumberish;
+      }
+    ] = [vCollectionId, { duration: vDuration, price: vPrice }];
+
+    if (accountDetails.sharingContractAllowance >= BigInt(vPrice)) {
+      tx = await sharingContract.subscribeToCollection(
+        ...subscribeToCollectionCallParams,
+        txOptions
+      );
+    } else {
+      const callData = sharingContract.interface.encodeFunctionData(
+        'subscribeToCollection',
+        subscribeToCollectionCallParams
+      );
+      tx = await pocoContract.approveAndCall(
+        sharingContractAddress,
+        vPrice,
+        callData,
+        txOptions
+      );
+    }
     await tx.wait();
 
     return {

--- a/packages/sdk/src/lib/types/pocoTypes.ts
+++ b/packages/sdk/src/lib/types/pocoTypes.ts
@@ -1,0 +1,4 @@
+export type AccountDetails = {
+  balance: bigint;
+  sharingContractAllowance: bigint;
+};

--- a/packages/sdk/tests/e2e/dataProtectorSharing/addToCollection.test.ts
+++ b/packages/sdk/tests/e2e/dataProtectorSharing/addToCollection.test.ts
@@ -3,7 +3,7 @@ import { type HDNodeWallet, Wallet } from 'ethers';
 import { IExec } from 'iexec';
 import { DEFAULT_SHARING_CONTRACT_ADDRESS } from '../../../src/config/config.js';
 import { IExecDataProtector } from '../../../src/index.js';
-import { approveCollectionContract } from '../../../src/lib/dataProtectorSharing/smartContract/approveCollectionContract.js';
+import { approveProtectedDataForCollectionContract } from '../../../src/lib/dataProtectorSharing/smartContract/approveProtectedDataForCollectionContract.js';
 import { getTestConfig, timeouts } from '../../test-utils.js';
 
 describe('dataProtector.addToCollection()', () => {
@@ -73,7 +73,7 @@ describe('dataProtector.addToCollection()', () => {
           { ethProvider },
           { ipfsGatewayURL: options.ipfsGateway, ...options?.iexecOptions }
         );
-        await approveCollectionContract({
+        await approveProtectedDataForCollectionContract({
           iexec,
           protectedData,
           sharingContractAddress: DEFAULT_SHARING_CONTRACT_ADDRESS,

--- a/packages/sdk/tests/e2e/dataProtectorSharing/buyProtectedData.test.ts
+++ b/packages/sdk/tests/e2e/dataProtectorSharing/buyProtectedData.test.ts
@@ -1,8 +1,14 @@
 import { beforeAll, describe, expect, it } from '@jest/globals';
 import { Wallet, type HDNodeWallet } from 'ethers';
 import { ValidationError } from 'yup';
+import { DEFAULT_SHARING_CONTRACT_ADDRESS } from '../../../src/config/config.js';
 import { IExecDataProtector } from '../../../src/index.js';
-import { getTestConfig, timeouts } from '../../test-utils.js';
+import {
+  approveAccount,
+  depositNRlcForAccount,
+  getTestConfig,
+  timeouts,
+} from '../../test-utils.js';
 
 describe('dataProtector.buyProtectedData()', () => {
   let seller: HDNodeWallet;
@@ -19,64 +25,153 @@ describe('dataProtector.buyProtectedData()', () => {
       ...getTestConfig(seller.privateKey)
     );
 
-    buyer = Wallet.createRandom();
-    dataProtectorForBuyer = new IExecDataProtector(
-      ...getTestConfig(buyer.privateKey)
-    );
-
-    const createCollectionResult1 =
+    const createSellerCollectionResult =
       await dataProtectorForSeller.sharing.createCollection();
-    sellerCollectionId = createCollectionResult1.collectionId;
-
-    const createCollectionResult2 =
-      await dataProtectorForBuyer.sharing.createCollection();
-    buyerCollectionId = createCollectionResult2.collectionId;
+    sellerCollectionId = createSellerCollectionResult.collectionId;
 
     const addOnlyAppWhitelistResponse =
       await dataProtectorForSeller.sharing.createAddOnlyAppWhitelist();
     addOnlyAppWhitelist = addOnlyAppWhitelistResponse.addOnlyAppWhitelist;
   }, 2 * timeouts.createCollection);
 
-  describe('When calling buyProtectedData() WITHOUT a collectionIdTo', () => {
-    it(
-      'should answer with success true and transfer ownership',
-      async () => {
-        const result = await dataProtectorForSeller.core.protectData({
-          name: 'test',
-          data: { doNotUse: 'test buyProtectedData' },
-        });
-        await dataProtectorForSeller.sharing.addToCollection({
-          protectedData: result.address,
-          addOnlyAppWhitelist,
-          collectionId: sellerCollectionId,
-        });
-
-        const price = 0;
-        await dataProtectorForSeller.sharing.setProtectedDataForSale({
-          protectedData: result.address,
-          price,
-        });
-
-        // --- WHEN
-        const buyProtectedDataResult =
-          await dataProtectorForBuyer.sharing.buyProtectedData({
-            protectedData: result.address,
-            price,
-          });
-
-        // --- THEN
-        expect(buyProtectedDataResult).toEqual({
-          txHash: expect.any(String),
-        });
-      },
-      timeouts.protectData +
-        timeouts.addToCollection +
-        timeouts.setProtectedDataForSale +
-        timeouts.buyProtectedData
+  beforeEach(async () => {
+    // use a brand new wallet for the buyer
+    buyer = Wallet.createRandom();
+    dataProtectorForBuyer = new IExecDataProtector(
+      ...getTestConfig(buyer.privateKey)
     );
   });
 
+  describe('When calling buyProtectedData() WITHOUT a collectionIdTo', () => {
+    describe('when the buyer has NOT enough nRlc on her/his account', () => {
+      it(
+        'should throw with the corresponding error',
+        async () => {
+          const result = await dataProtectorForSeller.core.protectData({
+            name: 'test',
+            data: { doNotUse: 'test buyProtectedData' },
+          });
+          await dataProtectorForSeller.sharing.addToCollection({
+            protectedData: result.address,
+            addOnlyAppWhitelist,
+            collectionId: sellerCollectionId,
+          });
+
+          const price = 1;
+          await dataProtectorForSeller.sharing.setProtectedDataForSale({
+            protectedData: result.address,
+            price,
+          });
+          // --- WHEN / THEN
+          await expect(
+            dataProtectorForBuyer.sharing.buyProtectedData({
+              protectedData: result.address,
+              price,
+            })
+          ).rejects.toThrow(new Error('Account balance is insufficient.'));
+        },
+        timeouts.protectData +
+          timeouts.addToCollection +
+          timeouts.setProtectedDataForSale +
+          timeouts.buyProtectedData
+      );
+    });
+    describe('when the buyer has enough nRlc on her/his account', () => {
+      describe('when the buyer has approved the contract to debit the account', () => {
+        it(
+          'should answer with success true and transfer ownership',
+          async () => {
+            const result = await dataProtectorForSeller.core.protectData({
+              name: 'test',
+              data: { doNotUse: 'test buyProtectedData' },
+            });
+            await dataProtectorForSeller.sharing.addToCollection({
+              protectedData: result.address,
+              addOnlyAppWhitelist,
+              collectionId: sellerCollectionId,
+            });
+
+            const price = 100;
+            await dataProtectorForSeller.sharing.setProtectedDataForSale({
+              protectedData: result.address,
+              price,
+            });
+
+            await depositNRlcForAccount(buyer.address, price);
+            await approveAccount(
+              buyer.privateKey,
+              DEFAULT_SHARING_CONTRACT_ADDRESS,
+              price
+            );
+
+            // --- WHEN
+            const buyProtectedDataResult =
+              await dataProtectorForBuyer.sharing.buyProtectedData({
+                protectedData: result.address,
+                price,
+              });
+
+            // --- THEN
+            expect(buyProtectedDataResult).toEqual({
+              txHash: expect.any(String),
+            });
+          },
+          timeouts.protectData +
+            timeouts.addToCollection +
+            timeouts.setProtectedDataForSale +
+            timeouts.buyProtectedData
+        );
+      });
+      describe('when the buyer has NOT approved the contract to debit the account', () => {
+        it(
+          'should approveAndCall and answer with success true and transfer ownership',
+          async () => {
+            const result = await dataProtectorForSeller.core.protectData({
+              name: 'test',
+              data: { doNotUse: 'test buyProtectedData' },
+            });
+            await dataProtectorForSeller.sharing.addToCollection({
+              protectedData: result.address,
+              addOnlyAppWhitelist,
+              collectionId: sellerCollectionId,
+            });
+
+            const price = 100;
+            await dataProtectorForSeller.sharing.setProtectedDataForSale({
+              protectedData: result.address,
+              price,
+            });
+
+            await depositNRlcForAccount(buyer.address, price);
+
+            // --- WHEN
+            const buyProtectedDataResult =
+              await dataProtectorForBuyer.sharing.buyProtectedData({
+                protectedData: result.address,
+                price,
+              });
+
+            // --- THEN
+            expect(buyProtectedDataResult).toEqual({
+              txHash: expect.any(String),
+            });
+          },
+          timeouts.protectData +
+            timeouts.addToCollection +
+            timeouts.setProtectedDataForSale +
+            timeouts.buyProtectedData
+        );
+      });
+    });
+  });
+
   describe('When calling buyProtectedData() WITH a collectionIdTo', () => {
+    beforeEach(async () => {
+      const createBuyerCollectionResult =
+        await dataProtectorForBuyer.sharing.createCollection();
+      buyerCollectionId = createBuyerCollectionResult.collectionId;
+    }, timeouts.createCollection);
+
     it(
       "should answer with success true and add it to new owner's collection",
       async () => {

--- a/packages/sdk/tests/e2e/dataProtectorSharing/subscribeToCollection.test.ts
+++ b/packages/sdk/tests/e2e/dataProtectorSharing/subscribeToCollection.test.ts
@@ -1,49 +1,160 @@
 import { beforeAll, describe, expect, it } from '@jest/globals';
-import { Wallet } from 'ethers';
+import { HDNodeWallet, Wallet } from 'ethers';
+import { DEFAULT_SHARING_CONTRACT_ADDRESS } from '../../../src/config/config.js';
 import { IExecDataProtector } from '../../../src/index.js';
-import { getTestConfig, timeouts } from '../../test-utils.js';
+import {
+  approveAccount,
+  depositNRlcForAccount,
+  getTestConfig,
+  timeouts,
+} from '../../test-utils.js';
 
-describe('dataProtector.subscribe()', () => {
+describe('dataProtector.subscribeToCollection()', () => {
+  let walletEndUser: HDNodeWallet;
   let dataProtectorCreator: IExecDataProtector;
   let dataProtectorEndUser: IExecDataProtector;
 
   beforeAll(async () => {
     const walletCreator = Wallet.createRandom();
-    const walletEndUser = Wallet.createRandom();
     dataProtectorCreator = new IExecDataProtector(
       ...getTestConfig(walletCreator.privateKey)
     );
+  });
+
+  beforeEach(() => {
+    // use a brand new wallet for the renter
+    walletEndUser = Wallet.createRandom();
     dataProtectorEndUser = new IExecDataProtector(
       ...getTestConfig(walletEndUser.privateKey)
     );
   });
 
   describe('When calling subscribe()', () => {
-    it(
-      'should work',
-      async () => {
-        const { collectionId } =
-          await dataProtectorCreator.sharing.createCollection();
+    describe('when subscription is free', () => {
+      it(
+        'should work',
+        async () => {
+          const { collectionId } =
+            await dataProtectorCreator.sharing.createCollection();
 
-        const subscriptionParams = { price: 0, duration: 2000 };
-        await dataProtectorCreator.sharing.setSubscriptionParams({
-          collectionId,
-          ...subscriptionParams,
-        });
-
-        const subscribeResult =
-          await dataProtectorEndUser.sharing.subscribeToCollection({
+          const subscriptionParams = { price: 0, duration: 2000 };
+          await dataProtectorCreator.sharing.setSubscriptionParams({
             collectionId,
             ...subscriptionParams,
           });
-        expect(subscribeResult).toEqual({
-          txHash: expect.any(String),
+
+          const subscribeResult =
+            await dataProtectorEndUser.sharing.subscribeToCollection({
+              collectionId,
+              ...subscriptionParams,
+            });
+          expect(subscribeResult).toEqual({
+            txHash: expect.any(String),
+          });
+        },
+        timeouts.createCollection +
+          timeouts.setSubscriptionParams +
+          timeouts.subscribe
+      );
+    });
+    describe('when subscription is not free', () => {
+      describe('when the subscriber has NOT enough nRlc on her/his account', () => {
+        it(
+          'should throw the corresponding error',
+          async () => {
+            const { collectionId } =
+              await dataProtectorCreator.sharing.createCollection();
+
+            const subscriptionParams = { price: 100, duration: 2000 };
+            await dataProtectorCreator.sharing.setSubscriptionParams({
+              collectionId,
+              ...subscriptionParams,
+            });
+
+            await expect(
+              dataProtectorEndUser.sharing.subscribeToCollection({
+                collectionId,
+                ...subscriptionParams,
+              })
+            ).rejects.toThrow(new Error('Account balance is insufficient.'));
+          },
+          timeouts.createCollection +
+            timeouts.setSubscriptionParams +
+            timeouts.subscribe
+        );
+      });
+      describe('when the subscriber has enough nRlc on her/his account', () => {
+        describe('when the subscriber has approved the contract to debit the account', () => {
+          it(
+            'should work',
+            async () => {
+              const { collectionId } =
+                await dataProtectorCreator.sharing.createCollection();
+
+              const subscriptionParams = { price: 100, duration: 2000 };
+              await dataProtectorCreator.sharing.setSubscriptionParams({
+                collectionId,
+                ...subscriptionParams,
+              });
+
+              await depositNRlcForAccount(
+                walletEndUser.address,
+                subscriptionParams.price
+              );
+              await approveAccount(
+                walletEndUser.privateKey,
+                DEFAULT_SHARING_CONTRACT_ADDRESS,
+                subscriptionParams.price
+              );
+
+              const subscribeResult =
+                await dataProtectorEndUser.sharing.subscribeToCollection({
+                  collectionId,
+                  ...subscriptionParams,
+                });
+              expect(subscribeResult).toEqual({
+                txHash: expect.any(String),
+              });
+            },
+            timeouts.createCollection +
+              timeouts.setSubscriptionParams +
+              timeouts.subscribe
+          );
         });
-      },
-      timeouts.createCollection +
-        timeouts.setSubscriptionParams +
-        timeouts.subscribe
-    );
+        describe('when the subscriber has NOT approved the contract to debit the account', () => {
+          it(
+            'should approveAndCall and work',
+            async () => {
+              const { collectionId } =
+                await dataProtectorCreator.sharing.createCollection();
+
+              const subscriptionParams = { price: 100, duration: 2000 };
+              await dataProtectorCreator.sharing.setSubscriptionParams({
+                collectionId,
+                ...subscriptionParams,
+              });
+
+              await depositNRlcForAccount(
+                walletEndUser.address,
+                subscriptionParams.price
+              );
+
+              const subscribeResult =
+                await dataProtectorEndUser.sharing.subscribeToCollection({
+                  collectionId,
+                  ...subscriptionParams,
+                });
+              expect(subscribeResult).toEqual({
+                txHash: expect.any(String),
+              });
+            },
+            timeouts.createCollection +
+              timeouts.setSubscriptionParams +
+              timeouts.subscribe
+          );
+        });
+      });
+    });
   });
 
   describe('When calling subscribe() with invalid collection ID', () => {

--- a/packages/sdk/tests/test-utils.ts
+++ b/packages/sdk/tests/test-utils.ts
@@ -1,5 +1,5 @@
-import { Wallet } from 'ethers';
-import { IExecAppModule, TeeFramework, utils } from 'iexec';
+import { Wallet, JsonRpcProvider, ethers } from 'ethers';
+import { IExecAppModule, IExecConfig, TeeFramework, utils } from 'iexec';
 import {
   DataProtectorConfigOptions,
   Web3SignerProvider,
@@ -7,22 +7,30 @@ import {
 } from '../src/index.js';
 import { WAIT_FOR_SUBGRAPH_INDEXING } from './unit/utils/waitForSubgraphIndexing.js';
 
-export const getTestWeb3SignerProvider = (
-  privateKey: string
-): Web3SignerProvider =>
-  utils.getSignerFromPrivateKey(
-    process.env.DRONE ? 'http://bellecour-fork:8545' : 'http://127.0.0.1:8545',
-    privateKey
-  );
+const { DRONE } = process.env;
 
-const getTestIExecOption = () => ({
-  smsURL: process.env.DRONE ? 'http://sms:13300' : 'http://127.0.0.1:13300',
-  resultProxyURL: process.env.DRONE
+const TEST_CHAIN = {
+  rpcURL: DRONE ? 'http://bellecour-fork:8545' : 'http://localhost:8545',
+  chainId: '134',
+  smsURL: DRONE ? 'http://sms:13300' : 'http://127.0.0.1:13300',
+  resultProxyURL: DRONE
     ? 'http://result-proxy:13200'
     : 'http://127.0.0.1:13200',
-  iexecGatewayURL: process.env.DRONE
-    ? 'http://market-api:3000'
-    : 'http://127.0.0.1:3000',
+  iexecGatewayURL: DRONE ? 'http://market-api:3000' : 'http://127.0.0.1:3000',
+  provider: new JsonRpcProvider(
+    DRONE ? 'http://bellecour-fork:8545' : 'http://localhost:8545'
+  ),
+};
+
+export const getTestWeb3SignerProvider = (
+  privateKey: string = Wallet.createRandom().privateKey
+): Web3SignerProvider =>
+  utils.getSignerFromPrivateKey(TEST_CHAIN.rpcURL, privateKey);
+
+export const getTestIExecOption = () => ({
+  smsURL: TEST_CHAIN.smsURL,
+  resultProxyURL: TEST_CHAIN.resultProxyURL,
+  iexecGatewayURL: TEST_CHAIN.iexecGatewayURL,
 });
 
 export const getTestConfig = (
@@ -405,4 +413,47 @@ export const MOCK_WORKERPOOL_ORDER = {
 export const EMPTY_ORDER_BOOK: any = {
   orders: [],
   count: 0,
+};
+
+export const setBalance = async (
+  address: string,
+  targetWeiBalance: ethers.BigNumberish
+) => {
+  await fetch(TEST_CHAIN.rpcURL, {
+    method: 'POST',
+    body: JSON.stringify({
+      method: 'anvil_setBalance',
+      params: [address, ethers.toBeHex(targetWeiBalance)],
+      id: 1,
+      jsonrpc: '2.0',
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};
+
+export const setNRlcBalance = async (
+  address: string,
+  nRlcTargetBalance: ethers.BigNumberish
+) => {
+  const weiAmount = BigInt(`${nRlcTargetBalance}`) * BigInt(1_000_000_000); // 1 nRLC is 10^9 wei
+  await setBalance(address, weiAmount);
+};
+
+export const depositNRlcForAccount = async (
+  address: string,
+  nRlcAmount: ethers.BigNumberish
+) => {
+  const sponsorWallet = Wallet.createRandom();
+  await setNRlcBalance(sponsorWallet.address, nRlcAmount);
+  const ethProvider = getTestConfig(sponsorWallet.privateKey)[0];
+  const iexecConfig = new IExecConfig({ ethProvider });
+  const { getIExecContract } = await iexecConfig.resolveContractsClient();
+  const iexecContract = getIExecContract();
+  const tx = await iexecContract.depositFor(address, {
+    value: BigInt(nRlcAmount) * BigInt(1_000_000_000), // 1 nRLC is 10^9 wei
+    gasPrice: 0,
+  });
+  await tx.wait();
 };

--- a/packages/sdk/tests/test-utils.ts
+++ b/packages/sdk/tests/test-utils.ts
@@ -153,6 +153,8 @@ export const timeouts = {
   consumeProtectedData:
     // appForProtectedData + ownerOf + consumeProtectedData + fetchWorkerpoolOrderbook (20sec?)
     SUBGRAPH_CALL_TIMEOUT + 3 * SMART_CONTRACT_CALL_TIMEOUT + 20_000,
+
+  tx: 2 * MAX_EXPECTED_BLOCKTIME,
 };
 
 export const MOCK_DATASET_ORDER = {
@@ -453,6 +455,21 @@ export const depositNRlcForAccount = async (
   const iexecContract = getIExecContract();
   const tx = await iexecContract.depositFor(address, {
     value: BigInt(nRlcAmount) * BigInt(1_000_000_000), // 1 nRLC is 10^9 wei
+    gasPrice: 0,
+  });
+  await tx.wait();
+};
+
+export const approveAccount = async (
+  privateKey: string,
+  approvedAddress: string,
+  nRlcAmount: ethers.BigNumberish
+) => {
+  const ethProvider = getTestConfig(privateKey)[0];
+  const iexecConfig = new IExecConfig({ ethProvider });
+  const { getIExecContract } = await iexecConfig.resolveContractsClient();
+  const iexecContract = getIExecContract();
+  const tx = await iexecContract.approve(approvedAddress, nRlcAmount, {
     gasPrice: 0,
   });
   await tx.wait();

--- a/packages/sdk/tests/unit/dataProtectorSharing/approveProtectedDataForCollectionContract.test.ts
+++ b/packages/sdk/tests/unit/dataProtectorSharing/approveProtectedDataForCollectionContract.test.ts
@@ -32,8 +32,8 @@ describe('approveCollectionContract', () => {
         }
       );
 
-      const { approveCollectionContract } = await import(
-        '../../../src/lib/dataProtectorSharing/smartContract/approveCollectionContract.js'
+      const { approveProtectedDataForCollectionContract } = await import(
+        '../../../src/lib/dataProtectorSharing/smartContract/approveProtectedDataForCollectionContract.js'
       );
       const ethProvider = getWeb3Provider(Wallet.createRandom().privateKey);
       const iexec = new IExec({
@@ -41,7 +41,7 @@ describe('approveCollectionContract', () => {
       });
 
       // --- WHEN
-      await approveCollectionContract({
+      await approveProtectedDataForCollectionContract({
         iexec,
         protectedData: ethers.ZeroAddress,
         sharingContractAddress: '0x2f...',
@@ -72,8 +72,8 @@ describe('approveCollectionContract', () => {
         }
       );
 
-      const { approveCollectionContract } = await import(
-        '../../../src/lib/dataProtectorSharing/smartContract/approveCollectionContract.js'
+      const { approveProtectedDataForCollectionContract } = await import(
+        '../../../src/lib/dataProtectorSharing/smartContract/approveProtectedDataForCollectionContract.js'
       );
       const ethProvider = getWeb3Provider(Wallet.createRandom().privateKey);
       const iexec = new IExec({
@@ -81,7 +81,7 @@ describe('approveCollectionContract', () => {
       });
 
       // --- WHEN
-      await approveCollectionContract({
+      await approveProtectedDataForCollectionContract({
         iexec,
         protectedData: '0xc72e3fc8395f9410cc838bc1962b389229015ed5',
         sharingContractAddress: '0x2f...',

--- a/packages/sharing-smart-contract/abis/interfaces/IExecPocoDelegate.sol/IExecPocoDelegate.json
+++ b/packages/sharing-smart-contract/abis/interfaces/IExecPocoDelegate.sol/IExecPocoDelegate.json
@@ -3,6 +3,30 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "spender",
         "type": "address"
       },

--- a/packages/sharing-smart-contract/contracts/interfaces/IExecPocoDelegate.sol
+++ b/packages/sharing-smart-contract/contracts/interfaces/IExecPocoDelegate.sol
@@ -100,4 +100,6 @@ interface IExecPocoDelegate {
     function deposit() external payable returns (bool);
 
     function approveAndCall(address spender, uint256 value, bytes calldata extraData) external returns (bool);
+
+    function allowance(address owner, address spender) external view returns (uint256);
 }


### PR DESCRIPTION
For account payable methods

- check if the user account balance is sufficient
- check allowance
- in case of insufficient allowance use `approveAndCall` to approve the sharing contract to debit the user and perform the 

Updated methods

- [x] buyProtectedData + tests
```
 PASS  tests/e2e/dataProtectorSharing/buyProtectedData.test.ts (145.081 s)
  dataProtector.buyProtectedData()
    When calling buyProtectedData() WITHOUT a collectionIdTo
      when the buyer has NOT enough nRlc on her/his account
        ✓ should throw with the corresponding error (20696 ms)
      when the buyer has enough nRlc on her/his account
        when the buyer has approved the contract to debit the account
          ✓ should answer with success true and transfer ownership (31439 ms)
        when the buyer has NOT approved the contract to debit the account
          ✓ should approveAndCall and answer with success true and transfer ownership (26904 ms)
    When calling buyProtectedData() WITH a collectionIdTo
      ✓ should answer with success true and add it to new owner's collection (35780 ms)
    When the given protected data address is not a valid address
      ✓ should throw with the corresponding error (27 ms)
    When the given protected data does NOT exist
      ✓ should fail if the protected data is not a part of a collection (261 ms)
    When the given protected data is not currently for sale
      ✓ should throw an error (19695 ms)
```
- [x] rentProtectedData + tests
```
 PASS  tests/e2e/dataProtectorSharing/rentProtectedData.test.ts (144.912 s)
  dataProtector.rentProtectedData()
    When calling rentProtectedData()
      when renting is free
        ✓ should answer with success true (28218 ms)
      when renting is not free
        when the renter has NOT enough nRlc on her/his account
          ✓ should throw the corresponding error (23148 ms)
        when the renter has enough nRlc on her/his account
          when the buyer has approved the contract to debit the account
            ✓ should answer with success true (35811 ms)
          when the buyer has NOT approved the contract to debit the account
            ✓ should approveAndCall and answer with success true (31762 ms)
    When calling rentProtectedData() when Protected Data is not set to renting
      ✓ should throw the corresponding error (19682 ms)
    When the given protected data address is not a valid address
      ✓ should throw with the corresponding error (28 ms)
```
- [x] subscribeToCollection + tests
```
 PASS  tests/e2e/dataProtectorSharing/subscribeToCollection.test.ts (64.148 s)
  dataProtector.subscribeToCollection()
    When calling subscribe()
      when subscription is free
        ✓ should work (14313 ms)
      when subscription is not free
        when the subscriber has NOT enough nRlc on her/his account
          ✓ should throw the corresponding error (8945 ms)
        when the subscriber has enough nRlc on her/his account
          when the subscriber has approved the contract to debit the account
            ✓ should work (21761 ms)
          when the subscriber has NOT approved the contract to debit the account
            ✓ should approveAndCall and work (17305 ms)
    When calling subscribe() with invalid collection ID
      ✓ should throw the corresponding error (36 ms)
    When calling subscribe() with collection ID that does not exist
      ✓ should throw the corresponding error (216 ms)
```
- [ ] consumeProtectedData (TODO when non-free wokerpoolorders are supported)
