### PR TITLE
Feature/fix error type

### DIFF
--- a/packages/sdk/src/utils/fetchOrdersUnderMaxPrice.ts
+++ b/packages/sdk/src/utils/fetchOrdersUnderMaxPrice.ts
@@ -5,7 +5,6 @@ import {
   PublishedWorkerpoolorder,
 } from 'iexec/IExecOrderbookModule';
 import { DEFAULT_MAX_PRICE } from '../config/config.js';
-import { validateOrders } from './validators.js';
 
 export const fetchOrdersUnderMaxPrice = (
   datasetOrderbook: PaginableOrders<PublishedDatasetorder>,
@@ -13,13 +12,18 @@ export const fetchOrdersUnderMaxPrice = (
   workerpoolOrderbook: PaginableOrders<PublishedWorkerpoolorder>,
   vMaxPrice = DEFAULT_MAX_PRICE
 ) => {
-  validateOrders().label('dataset').validateSync(datasetOrderbook.orders);
-  validateOrders().label('app').validateSync(appOrderbook.orders);
-  validateOrders().label('workerpool').validateSync(workerpoolOrderbook.orders);
-
   const datasetorder = datasetOrderbook.orders[0]?.order;
+  if (!datasetorder) {
+    throw new Error(`No dataset orders found`);
+  }
   const apporder = appOrderbook.orders[0]?.order;
+  if (!apporder) {
+    throw new Error(`No app orders found`);
+  }
   const workerpoolorder = workerpoolOrderbook.orders[0]?.order;
+  if (!workerpoolorder) {
+    throw new Error(`No workerpool orders found`);
+  }
 
   const totalPrice =
     datasetorder.datasetprice +

--- a/packages/sdk/src/utils/validators.ts
+++ b/packages/sdk/src/utils/validators.ts
@@ -99,18 +99,6 @@ export const grantedAccessSchema = () =>
 
 export const urlArraySchema = () => array().of(urlSchema());
 
-export const validateOrders = () =>
-  array().test(
-    'is-not-empty-orderbook',
-    ({ label }) => `No ${label} orders found`,
-    (value) => {
-      if (!value || value.length === 0) {
-        return false;
-      }
-      return true;
-    }
-  );
-
 export const secretsSchema = () =>
   object().test(
     'is-valid-secret',

--- a/packages/sdk/tests/unit/dataProtectorCore/processProtectedData.test.ts
+++ b/packages/sdk/tests/unit/dataProtectorCore/processProtectedData.test.ts
@@ -21,6 +21,7 @@ import {
 import { fetchOrdersUnderMaxPrice } from '../../../src/utils/fetchOrdersUnderMaxPrice.js';
 import { getWeb3Provider } from '../../../src/utils/getWeb3Provider.js';
 import {
+  EMPTY_ORDER_BOOK,
   MAX_EXPECTED_BLOCKTIME,
   MAX_EXPECTED_WEB2_SERVICES_TIME,
   MOCK_APP_ORDER,
@@ -74,7 +75,7 @@ describe('processProtectedData', () => {
     'should throw WorkflowError for missing Dataset order',
     async () => {
       mockFetchDatasetOrderbook = jest.fn().mockImplementationOnce(() => {
-        return Promise.resolve({});
+        return Promise.resolve(EMPTY_ORDER_BOOK);
       });
       iexec.orderbook.fetchDatasetOrderbook = mockFetchDatasetOrderbook;
       await expect(
@@ -102,7 +103,7 @@ describe('processProtectedData', () => {
     'should throw WorkflowError for missing App order',
     async () => {
       mockFetchAppOrderbook = jest.fn().mockImplementationOnce(() => {
-        return Promise.resolve({});
+        return Promise.resolve(EMPTY_ORDER_BOOK);
       });
 
       iexec.orderbook.fetchAppOrderbook = mockFetchAppOrderbook;
@@ -131,7 +132,7 @@ describe('processProtectedData', () => {
     'should throw WorkflowError for missing Workerpool order',
     async () => {
       mockFetchWorkerpoolOrderbook = jest.fn().mockImplementationOnce(() => {
-        return Promise.resolve({});
+        return Promise.resolve(EMPTY_ORDER_BOOK);
       });
       iexec.orderbook.fetchWorkerpoolOrderbook = mockFetchWorkerpoolOrderbook;
 

--- a/packages/sdk/tests/unit/utils/validators.test.ts
+++ b/packages/sdk/tests/unit/utils/validators.test.ts
@@ -9,16 +9,8 @@ import {
   secretsSchema,
   positiveNumberSchema,
   numberBetweenSchema,
-  validateOrders,
 } from '../../../src/utils/validators.js';
-import {
-  EMPTY_ORDER_BOOK,
-  MOCK_APP_ORDER,
-  MOCK_DATASET_ORDER,
-  MOCK_WORKERPOOL_ORDER,
-  getRandomAddress,
-  getRequiredFieldMessage,
-} from '../../test-utils.js';
+import { getRandomAddress, getRequiredFieldMessage } from '../../test-utils.js';
 
 const CANNOT_BE_NULL_ERROR = new ValidationError('this cannot be null');
 const IS_REQUIRED_ERROR = new ValidationError(getRequiredFieldMessage());
@@ -565,48 +557,5 @@ describe('validateRecord', () => {
         .label('recordWithInvalidValue')
         .validateSync(recordWithInvalidValue)
     ).toThrow(IS_NOT_VALID_RECORD);
-  });
-});
-
-describe('validateOrders', () => {
-  it('should validate a valid datasetOrderbook', () => {
-    expect(() =>
-      validateOrders().label('dataset').validateSync(MOCK_DATASET_ORDER.orders)
-    ).not.toThrow();
-  });
-
-  it('should throw an error for empty datasetOrderbook', () => {
-    const EMPTY_DATESET_ERROR = 'No dataset orders found';
-    expect(() =>
-      validateOrders().label('dataset').validateSync(EMPTY_ORDER_BOOK.orders)
-    ).toThrow(EMPTY_DATESET_ERROR);
-  });
-
-  it('should validate a valid appOrderbook', () => {
-    expect(() =>
-      validateOrders().label('app').validateSync(MOCK_APP_ORDER.orders)
-    ).not.toThrow();
-  });
-
-  it('should throw an error for empty appOrderbook', () => {
-    const EMPTY_APP_ERROR = 'No app orders found';
-    expect(() =>
-      validateOrders().label('app').validateSync(EMPTY_ORDER_BOOK.orders)
-    ).toThrow(EMPTY_APP_ERROR);
-  });
-
-  it('should validate a valid workerpoolOrderbook', () => {
-    expect(() =>
-      validateOrders()
-        .label('workerpool')
-        .validateSync(MOCK_WORKERPOOL_ORDER.orders)
-    ).not.toThrow();
-  });
-
-  it('should throw an error for empty workerpoolOrderbook', () => {
-    const EMPTY_WORKERPOOL_ERROR = 'No workerpool orders found';
-    expect(() =>
-      validateOrders().label('workerpool').validateSync(EMPTY_ORDER_BOOK.orders)
-    ).toThrow(EMPTY_WORKERPOOL_ERROR);
   });
 });


### PR DESCRIPTION
# issue

`processProtectedData` throws a `ValidationError` when an orderbook is empty.
`ValidationError` is a specific kind of error for user input validation.
This error is unsuitable as the orderbook is not a user input.

# fix

empty orderbook now throw a plain `Error`