### PR TITLE
add consumeProtectedData legacy overload for backward compatibility

### DIFF
--- a/packages/protected-data-delivery-dapp/deployment/abis/DataProtectorSharingABI.json
+++ b/packages/protected-data-delivery-dapp/deployment/abis/DataProtectorSharingABI.json
@@ -1237,6 +1237,92 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_protectedData",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "workerpool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "workerpoolprice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "volume",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "tag",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "category",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "trust",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "apprestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "datasetrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "requesterrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "salt",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "sign",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IexecLibOrders_v5.WorkerpoolOrder",
+        "name": "_workerpoolOrder",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "_app",
+        "type": "address"
+      }
+    ],
+    "name": "consumeProtectedData",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "dealid",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_to",
         "type": "address"
       }

--- a/packages/sdk/abis/sharing/DataProtectorSharing.sol/DataProtectorSharing.json
+++ b/packages/sdk/abis/sharing/DataProtectorSharing.sol/DataProtectorSharing.json
@@ -1237,6 +1237,92 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_protectedData",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "workerpool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "workerpoolprice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "volume",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "tag",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "category",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "trust",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "apprestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "datasetrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "requesterrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "salt",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "sign",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IexecLibOrders_v5.WorkerpoolOrder",
+        "name": "_workerpoolOrder",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "_app",
+        "type": "address"
+      }
+    ],
+    "name": "consumeProtectedData",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "dealid",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_to",
         "type": "address"
       }

--- a/packages/sdk/abis/sharing/interfaces/IDataProtectorSharing.sol/IDataProtectorSharing.json
+++ b/packages/sdk/abis/sharing/interfaces/IDataProtectorSharing.sol/IDataProtectorSharing.json
@@ -781,6 +781,92 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_protectedData",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "workerpool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "workerpoolprice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "volume",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "tag",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "category",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "trust",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "apprestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "datasetrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "requesterrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "salt",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "sign",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IexecLibOrders_v5.WorkerpoolOrder",
+        "name": "_workerpoolOrder",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "_app",
+        "type": "address"
+      }
+    ],
+    "name": "consumeProtectedData",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_to",
         "type": "address"
       }

--- a/packages/sdk/src/lib/dataProtectorSharing/consumeProtectedData.ts
+++ b/packages/sdk/src/lib/dataProtectorSharing/consumeProtectedData.ts
@@ -47,6 +47,10 @@ import {
 } from './smartContract/preflightChecks.js';
 import { getProtectedDataDetails } from './smartContract/sharingContract.reads.js';
 
+// consumeProtectedData is overloaded, we need to specify which method to use
+const CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION =
+  'consumeProtectedData(address,(address,uint256,uint256,bytes32,uint256,uint256,address,address,address,bytes32,bytes),address,bool)';
+
 export const consumeProtectedData = async ({
   iexec = throwIfMissing(),
   sharingContractAddress = throwIfMissing(),
@@ -248,14 +252,14 @@ export const consumeProtectedData = async ({
         accountDetails.spenderAllowance >= // if !vUseVoucher accountDetails is null
           BigInt(workerpoolOrder.workerpoolprice)
       ) {
-        tx = await sharingContract.consumeProtectedData(
+        tx = await sharingContract[CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](
           ...consumeProtectedDataCallParams,
           txOptions
         );
       } else {
         //Go here if: we are not in voucher mode and we have insufficient allowance for the spender (sharingContract)
         const callData = sharingContract.interface.encodeFunctionData(
-          'consumeProtectedData',
+          CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION,
           consumeProtectedDataCallParams
         );
         tx = await pocoContract.approveAndCall(

--- a/packages/sharing-smart-contract/abis/DataProtectorSharing.sol/DataProtectorSharing.json
+++ b/packages/sharing-smart-contract/abis/DataProtectorSharing.sol/DataProtectorSharing.json
@@ -1237,6 +1237,92 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_protectedData",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "workerpool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "workerpoolprice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "volume",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "tag",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "category",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "trust",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "apprestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "datasetrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "requesterrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "salt",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "sign",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IexecLibOrders_v5.WorkerpoolOrder",
+        "name": "_workerpoolOrder",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "_app",
+        "type": "address"
+      }
+    ],
+    "name": "consumeProtectedData",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "dealid",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_to",
         "type": "address"
       }

--- a/packages/sharing-smart-contract/abis/interfaces/IDataProtectorSharing.sol/IDataProtectorSharing.json
+++ b/packages/sharing-smart-contract/abis/interfaces/IDataProtectorSharing.sol/IDataProtectorSharing.json
@@ -781,6 +781,92 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_protectedData",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "workerpool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "workerpoolprice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "volume",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "tag",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "category",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "trust",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "apprestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "datasetrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "requesterrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "salt",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "sign",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IexecLibOrders_v5.WorkerpoolOrder",
+        "name": "_workerpoolOrder",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "_app",
+        "type": "address"
+      }
+    ],
+    "name": "consumeProtectedData",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_to",
         "type": "address"
       }

--- a/packages/sharing-smart-contract/contracts/DataProtectorSharing.sol
+++ b/packages/sharing-smart-contract/contracts/DataProtectorSharing.sol
@@ -157,6 +157,14 @@ contract DataProtectorSharing is
         return _consumeProtectedData(_protectedData, msg.sender, _workerpoolOrder, _app, _useVoucher);
     }
 
+    function consumeProtectedData(
+        address _protectedData,
+        IexecLibOrders_v5.WorkerpoolOrder memory _workerpoolOrder,
+        address _app
+    ) public returns (bytes32 dealid) {
+        return _consumeProtectedData(_protectedData, msg.sender, _workerpoolOrder, _app, false);
+    }
+
     function _consumeProtectedData(
         address _protectedData,
         address _spender,
@@ -256,7 +264,14 @@ contract DataProtectorSharing is
             (address protectedData, address to, uint72 price) = abi.decode(_extraData[4:], (address, address, uint72));
             _buyProtectedData(protectedData, _sender, to, price);
             return true;
-        } else if (selector == this.consumeProtectedData.selector) {
+        } else if (
+            selector ==
+            bytes4(
+                keccak256(
+                    "consumeProtectedData(address,(address,uint256,uint256,bytes32,uint256,uint256,address,address,address,bytes32,bytes),address,bool)"
+                )
+            )
+        ) {
             (
                 address protectedData,
                 IexecLibOrders_v5.WorkerpoolOrder memory workerpoolOrder,
@@ -265,8 +280,21 @@ contract DataProtectorSharing is
             ) = abi.decode(_extraData[4:], (address, IexecLibOrders_v5.WorkerpoolOrder, address, bool));
             _consumeProtectedData(protectedData, _sender, workerpoolOrder, app, useVoucher);
             return true;
+        } else if (
+            selector ==
+            bytes4(
+                keccak256(
+                    "consumeProtectedData(address,(address,uint256,uint256,bytes32,uint256,uint256,address,address,address,bytes32,bytes),address)"
+                )
+            )
+        ) {
+            (address protectedData, IexecLibOrders_v5.WorkerpoolOrder memory workerpoolOrder, address app) = abi.decode(
+                _extraData[4:],
+                (address, IexecLibOrders_v5.WorkerpoolOrder, address)
+            );
+            _consumeProtectedData(protectedData, _sender, workerpoolOrder, app, false);
+            return true;
         }
-
         return false;
     }
 

--- a/packages/sharing-smart-contract/contracts/DataProtectorSharing.sol
+++ b/packages/sharing-smart-contract/contracts/DataProtectorSharing.sol
@@ -265,12 +265,12 @@ contract DataProtectorSharing is
             _buyProtectedData(protectedData, _sender, to, price);
             return true;
         } else if (
-            selector ==
-            bytes4(
-                keccak256(
-                    "consumeProtectedData(address,(address,uint256,uint256,bytes32,uint256,uint256,address,address,address,bytes32,bytes),address,bool)"
-                )
-            )
+            // bytes4(
+            //     keccak256(
+            //         "consumeProtectedData(address,(address,uint256,uint256,bytes32,uint256,uint256,address,address,address,bytes32,bytes),address,bool)"
+            //     )
+            // )
+            selector == 0x79c428d2
         ) {
             (
                 address protectedData,
@@ -281,12 +281,12 @@ contract DataProtectorSharing is
             _consumeProtectedData(protectedData, _sender, workerpoolOrder, app, useVoucher);
             return true;
         } else if (
-            selector ==
-            bytes4(
-                keccak256(
-                    "consumeProtectedData(address,(address,uint256,uint256,bytes32,uint256,uint256,address,address,address,bytes32,bytes),address)"
-                )
-            )
+            // bytes4(
+            //     keccak256(
+            //         "consumeProtectedData(address,(address,uint256,uint256,bytes32,uint256,uint256,address,address,address,bytes32,bytes),address)"
+            //     )
+            // )
+            selector == 0xd835c337
         ) {
             (address protectedData, IexecLibOrders_v5.WorkerpoolOrder memory workerpoolOrder, address app) = abi.decode(
                 _extraData[4:],

--- a/packages/sharing-smart-contract/contracts/interfaces/IDataProtectorSharing.sol
+++ b/packages/sharing-smart-contract/contracts/interfaces/IDataProtectorSharing.sol
@@ -132,6 +132,21 @@ interface IDataProtectorSharing is ICollection, ISubscription, IRental, ISale {
     ) external returns (bytes32);
 
     /**
+     * Consume protected data by creating a deal on the iExec platform.
+     * Requires a valid subscription or rental for the protected data.
+     *
+     * @param _protectedData The address of the protected data.
+     * @param _workerpoolOrder The workerpool order for the computation task.
+     * @param _app The address of the app that will consume the protected data.
+     * @return The unique identifier (deal ID) of the created deal on the iExec platform.
+     */
+    function consumeProtectedData(
+        address _protectedData,
+        IexecLibOrders_v5.WorkerpoolOrder calldata _workerpoolOrder,
+        address _app
+    ) external returns (bytes32);
+
+    /**
      * Retrieves the rental expiration timestamp for a specific protected data and renter.
      * This function allows querying the expiration timestamp of a rental agreement
      * between a specific protected data item and a renter.

--- a/packages/sharing-smart-contract/test/e2e/consumeProtectedData.test.js
+++ b/packages/sharing-smart-contract/test/e2e/consumeProtectedData.test.js
@@ -12,7 +12,10 @@ import { voucherAuthorizeSharingContract } from './utils/voucher.utils.js';
 
 const { ethers } = pkg;
 
-describe('ConsumeProtectedData', () => {
+describe('ConsumeProtectedData voucher overload "consumeProtectedData(address,(address,uint256,uint256,bytes32,uint256,uint256,address,address,address,bytes32,bytes),address,bool)"', () => {
+  const CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION =
+    'consumeProtectedData(address,(address,uint256,uint256,bytes32,uint256,uint256,address,address,address,bytes32,bytes),address,bool)';
+
   describe('without voucher - consumeProtectedData()', () => {
     it('should create a deal on chain if an end user subscribe to the collection', async () => {
       const {
@@ -29,7 +32,7 @@ describe('ConsumeProtectedData', () => {
 
       const tx = await dataProtectorSharingContract
         .connect(addr2)
-        .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, false);
+        [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, false);
       await tx.wait();
 
       expect(tx)
@@ -57,7 +60,7 @@ describe('ConsumeProtectedData', () => {
       expect(
         dataProtectorSharingContract
           .connect(addr2)
-          .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, false),
+          [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, false),
       ).to.be.reverted;
     });
 
@@ -88,7 +91,48 @@ describe('ConsumeProtectedData', () => {
 
       const tx = await dataProtectorSharingContract
         .connect(addr2)
-        .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, false);
+        [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, false);
+      await tx.wait();
+
+      expect(tx)
+        .to.emit(dataProtectorSharingContract, 'ProtectedDataConsumed')
+        .withArgs((_dealId, _protectedDataAddress, _mode) => {
+          assert.equal(_dealId.constructor, ethers.Bytes32, 'DealId should be of type bytes32');
+          assert.equal(_protectedDataAddress, protectedDataAddress, 'DealId should be of type bytes32');
+          assert.equal(_mode, 0, 'Mode should be SUBSCRIPTION (0)');
+        });
+    });
+
+    it('should create a deal on chain if the user can pay for the workerpool with approveAndCall', async () => {
+      const {
+        dataProtectorSharingContract,
+        pocoContract,
+        protectedDataAddress,
+        appAddress,
+        collectionTokenId,
+        subscriptionParams,
+        addr2,
+      } = await loadFixture(createCollectionWithProtectedDataRentableAndSubscribableForFree);
+      const { workerpoolprice, workerpoolOrder } = await loadFixture(createNonFreeWorkerpoolOrder);
+
+      const depoTx = await pocoContract.connect(addr2).deposit({
+        value: ethers.parseUnits(workerpoolprice.toString(), 'gwei'),
+      }); // value sent should be in wei
+      depoTx.wait();
+
+      const subscribeTx = await dataProtectorSharingContract
+        .connect(addr2)
+        .subscribeToCollection(collectionTokenId, subscriptionParams);
+      subscribeTx.wait();
+
+      const callData = dataProtectorSharingContract.interface.encodeFunctionData(
+        CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION,
+        [protectedDataAddress, workerpoolOrder, appAddress, false],
+      );
+
+      const tx = await pocoContract
+        .connect(addr2)
+        .approveAndCall(await dataProtectorSharingContract.getAddress(), workerpoolprice, callData);
       await tx.wait();
 
       expect(tx)
@@ -108,7 +152,7 @@ describe('ConsumeProtectedData', () => {
 
       const tx = await dataProtectorSharingContract
         .connect(addr2)
-        .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, false);
+        [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, false);
       await tx.wait();
       expect(tx)
         .to.emit(dataProtectorSharingContract, 'ProtectedDataConsumed')
@@ -126,7 +170,7 @@ describe('ConsumeProtectedData', () => {
       await expect(
         dataProtectorSharingContract
           .connect(addr2)
-          .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, false),
+          [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, false),
       ).to.be.revertedWithCustomError(dataProtectorSharingContract, 'NoValidRentalOrSubscription');
     });
 
@@ -148,7 +192,7 @@ describe('ConsumeProtectedData', () => {
       await expect(
         dataProtectorSharingContract
           .connect(addr2)
-          .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, false),
+          [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, false),
       ).to.be.revertedWithCustomError(dataProtectorSharingContract, 'NoValidRentalOrSubscription');
     });
 
@@ -163,7 +207,7 @@ describe('ConsumeProtectedData', () => {
       await expect(
         dataProtectorSharingContract
           .connect(addr2)
-          .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, false),
+          [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, false),
       ).to.be.revertedWithCustomError(dataProtectorSharingContract, 'NoValidRentalOrSubscription');
     });
   });
@@ -184,7 +228,7 @@ describe('ConsumeProtectedData', () => {
 
       const tx = await dataProtectorSharingContract
         .connect(voucherOwner)
-        .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, true);
+        [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, true);
       await tx.wait();
 
       expect(tx)
@@ -211,7 +255,7 @@ describe('ConsumeProtectedData', () => {
       await expect(
         dataProtectorSharingContract
           .connect(voucherOwner)
-          .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, true),
+          [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, true),
       ).to.be.revertedWith('Voucher: voucher is expired'); // Replace 'Voucher is expired' with the actual revert message
     });
 
@@ -231,7 +275,7 @@ describe('ConsumeProtectedData', () => {
       await expect(
         dataProtectorSharingContract
           .connect(voucherOwner)
-          .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, true),
+          [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, true),
       ).to.be.reverted;
     });
 
@@ -247,7 +291,7 @@ describe('ConsumeProtectedData', () => {
       await expect(
         dataProtectorSharingContract
           .connect(voucherOwner)
-          .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, true),
+          [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, true),
       ).to.be.reverted;
     });
 
@@ -298,7 +342,7 @@ describe('ConsumeProtectedData', () => {
 
       const tx = await dataProtectorSharingContract
         .connect(voucherOwner)
-        .consumeProtectedData(protectedDataAddress, workerpoolOrder, appAddress, true);
+        [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress, true);
       await tx.wait();
 
       expect(tx)
@@ -308,6 +352,207 @@ describe('ConsumeProtectedData', () => {
           assert.equal(_protectedDataAddress, protectedDataAddress, 'DealId should be of type bytes32');
           assert.equal(_mode, 0, 'Mode should be SUBSCRIPTION (0)');
         });
+    });
+  });
+});
+
+describe('ConsumeProtectedData legacy overload "consumeProtectedData(address,(address,uint256,uint256,bytes32,uint256,uint256,address,address,address,bytes32,bytes),address)"', () => {
+  const CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION =
+    'consumeProtectedData(address,(address,uint256,uint256,bytes32,uint256,uint256,address,address,address,bytes32,bytes),address)';
+
+  describe('consumeProtectedData()', () => {
+    it('should create a deal on chain if an end user subscribe to the collection', async () => {
+      const {
+        dataProtectorSharingContract,
+        protectedDataAddress,
+        appAddress,
+        workerpoolOrder,
+        collectionTokenId,
+        subscriptionParams,
+        addr2,
+      } = await loadFixture(createCollectionWithProtectedDataRentableAndSubscribableForFree);
+
+      await dataProtectorSharingContract.connect(addr2).subscribeToCollection(collectionTokenId, subscriptionParams);
+
+      const tx = await dataProtectorSharingContract
+        .connect(addr2)
+        [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress);
+      await tx.wait();
+
+      expect(tx)
+        .to.emit(dataProtectorSharingContract, 'ProtectedDataConsumed')
+        .withArgs((_dealId, _protectedDataAddress, _mode) => {
+          assert.equal(_dealId.constructor, ethers.Bytes32, 'DealId should be of type bytes32');
+          assert.equal(_protectedDataAddress, protectedDataAddress, 'DealId should be of type bytes32');
+          assert.equal(_mode, 0, 'Mode should be SUBSCRIPTION (0)');
+        });
+    });
+
+    it('should revert if the user cannot pay for the workerpool', async () => {
+      const {
+        dataProtectorSharingContract,
+        protectedDataAddress,
+        appAddress,
+        collectionTokenId,
+        subscriptionParams,
+        addr2,
+      } = await loadFixture(createCollectionWithProtectedDataRentableAndSubscribableForFree);
+      const { workerpoolOrder } = await loadFixture(createNonFreeWorkerpoolOrder);
+
+      await dataProtectorSharingContract.connect(addr2).subscribeToCollection(collectionTokenId, subscriptionParams);
+
+      expect(
+        dataProtectorSharingContract
+          .connect(addr2)
+          [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress),
+      ).to.be.reverted;
+    });
+
+    it('should create a deal on chain if the user can pay for the workerpool', async () => {
+      const {
+        dataProtectorSharingContract,
+        pocoContract,
+        protectedDataAddress,
+        appAddress,
+        collectionTokenId,
+        subscriptionParams,
+        addr2,
+      } = await loadFixture(createCollectionWithProtectedDataRentableAndSubscribableForFree);
+      const { workerpoolprice, workerpoolOrder } = await loadFixture(createNonFreeWorkerpoolOrder);
+
+      const approveTx = await pocoContract
+        .connect(addr2)
+        .approve(await dataProtectorSharingContract.getAddress(), workerpoolprice);
+      approveTx.wait();
+      const depoTx = await pocoContract.connect(addr2).deposit({
+        value: ethers.parseUnits(workerpoolprice.toString(), 'gwei'),
+      }); // value sent should be in wei
+      depoTx.wait();
+      const subscribeTx = await dataProtectorSharingContract
+        .connect(addr2)
+        .subscribeToCollection(collectionTokenId, subscriptionParams);
+      subscribeTx.wait();
+
+      const tx = await dataProtectorSharingContract
+        .connect(addr2)
+        [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress);
+      await tx.wait();
+
+      expect(tx)
+        .to.emit(dataProtectorSharingContract, 'ProtectedDataConsumed')
+        .withArgs((_dealId, _protectedDataAddress, _mode) => {
+          assert.equal(_dealId.constructor, ethers.Bytes32, 'DealId should be of type bytes32');
+          assert.equal(_protectedDataAddress, protectedDataAddress, 'DealId should be of type bytes32');
+          assert.equal(_mode, 0, 'Mode should be SUBSCRIPTION (0)');
+        });
+    });
+
+    it('should create a deal on chain if the user can pay for the workerpool with approveAndCall', async () => {
+      const {
+        dataProtectorSharingContract,
+        pocoContract,
+        protectedDataAddress,
+        appAddress,
+        collectionTokenId,
+        subscriptionParams,
+        addr2,
+      } = await loadFixture(createCollectionWithProtectedDataRentableAndSubscribableForFree);
+      const { workerpoolprice, workerpoolOrder } = await loadFixture(createNonFreeWorkerpoolOrder);
+
+      const depoTx = await pocoContract.connect(addr2).deposit({
+        value: ethers.parseUnits(workerpoolprice.toString(), 'gwei'),
+      }); // value sent should be in wei
+      depoTx.wait();
+
+      const subscribeTx = await dataProtectorSharingContract
+        .connect(addr2)
+        .subscribeToCollection(collectionTokenId, subscriptionParams);
+      subscribeTx.wait();
+
+      const callData = dataProtectorSharingContract.interface.encodeFunctionData(
+        CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION,
+        [protectedDataAddress, workerpoolOrder, appAddress],
+      );
+
+      const tx = await pocoContract
+        .connect(addr2)
+        .approveAndCall(await dataProtectorSharingContract.getAddress(), workerpoolprice, callData);
+      await tx.wait();
+
+      expect(tx)
+        .to.emit(dataProtectorSharingContract, 'ProtectedDataConsumed')
+        .withArgs((_dealId, _protectedDataAddress, _mode) => {
+          assert.equal(_dealId.constructor, ethers.Bytes32, 'DealId should be of type bytes32');
+          assert.equal(_protectedDataAddress, protectedDataAddress, 'DealId should be of type bytes32');
+          assert.equal(_mode, 0, 'Mode should be SUBSCRIPTION (0)');
+        });
+    });
+
+    it('should create a deal on chain if an end user rent a protectedData inside a collection', async () => {
+      const { dataProtectorSharingContract, protectedDataAddress, appAddress, workerpoolOrder, rentingParams, addr2 } =
+        await loadFixture(createCollectionWithProtectedDataRentableAndSubscribableForFree);
+
+      await dataProtectorSharingContract.connect(addr2).rentProtectedData(protectedDataAddress, rentingParams);
+
+      const tx = await dataProtectorSharingContract
+        .connect(addr2)
+        [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress);
+      await tx.wait();
+      expect(tx)
+        .to.emit(dataProtectorSharingContract, 'ProtectedDataConsumed')
+        .withArgs((_dealId, _protectedDataAddress, _mode) => {
+          assert.equal(_dealId.constructor, ethers.Bytes32, 'DealId should be of type bytes32');
+          assert.equal(_protectedDataAddress, protectedDataAddress, 'DealId should be of type bytes32');
+          assert.equal(_mode, 1, 'Mode should be RENTING (1)');
+        });
+    });
+
+    it('should revert if the user does not have an ongoing subscription or rental', async () => {
+      const { dataProtectorSharingContract, protectedDataAddress, appAddress, workerpoolOrder, addr2 } =
+        await loadFixture(createCollectionWithProtectedDataRentableAndSubscribableForFree);
+
+      await expect(
+        dataProtectorSharingContract
+          .connect(addr2)
+          [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress),
+      ).to.be.revertedWithCustomError(dataProtectorSharingContract, 'NoValidRentalOrSubscription');
+    });
+
+    it('should revert if the user subscription is expired', async () => {
+      const {
+        dataProtectorSharingContract,
+        protectedDataAddress,
+        appAddress,
+        workerpoolOrder,
+        collectionTokenId,
+        subscriptionParams,
+        addr2,
+      } = await loadFixture(createCollectionWithProtectedDataRentableAndSubscribableForFree);
+
+      await dataProtectorSharingContract.connect(addr2).subscribeToCollection(collectionTokenId, subscriptionParams);
+      // advance time by one hour and mine a new block
+      await time.increase(subscriptionParams.duration);
+
+      await expect(
+        dataProtectorSharingContract
+          .connect(addr2)
+          [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress),
+      ).to.be.revertedWithCustomError(dataProtectorSharingContract, 'NoValidRentalOrSubscription');
+    });
+
+    it('should revert if the user rental is expired', async () => {
+      const { dataProtectorSharingContract, protectedDataAddress, appAddress, workerpoolOrder, rentingParams, addr2 } =
+        await loadFixture(createCollectionWithProtectedDataRentableAndSubscribableForFree);
+
+      await dataProtectorSharingContract.connect(addr2).rentProtectedData(protectedDataAddress, rentingParams);
+      // advance time by one hour and mine a new block
+      await time.increase(rentingParams.duration);
+
+      await expect(
+        dataProtectorSharingContract
+          .connect(addr2)
+          [CONSUME_PROTECTED_DATA_FUNCTION_DESCRIPTION](protectedDataAddress, workerpoolOrder, appAddress),
+      ).to.be.revertedWithCustomError(dataProtectorSharingContract, 'NoValidRentalOrSubscription');
     });
   });
 });

--- a/packages/subgraph/abis/DataProtectorSharingABI.json
+++ b/packages/subgraph/abis/DataProtectorSharingABI.json
@@ -1237,6 +1237,92 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_protectedData",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "workerpool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "workerpoolprice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "volume",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "tag",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "category",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "trust",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "apprestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "datasetrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "requesterrestrict",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "salt",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "sign",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IexecLibOrders_v5.WorkerpoolOrder",
+        "name": "_workerpoolOrder",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "_app",
+        "type": "address"
+      }
+    ],
+    "name": "consumeProtectedData",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "dealid",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_to",
         "type": "address"
       }


### PR DESCRIPTION
# feature

Added consumeProtectedData legacy overload (interface without "useVoucher") for backward compatibility with current SDK

# misc

- DataproectorSharing
  - contract uses precomputed function selectors for the overloaded methods
  - added tests for consumeProtectedData legacy overload
  - added tests for approveAndCall consumeProtectedData (legacy and voucher overloads)
  - updated abi in dependant packages
- sdk
  - use full function description to call `consumeProtectedData` on the contract