### PR TITLE
Feature/fix deserializer no protected data error

### DIFF
--- a/packages/dataprotector-deserializer/CHANGELOG.md
+++ b/packages/dataprotector-deserializer/CHANGELOG.md
@@ -1,1 +1,7 @@
+## Next
+
+### Changed
+
+- fixed cryptic TypeError when `@iexec/dataprotector-deserializer` was used in a context without protected data, `getValue()` now rejects with Error "Missing protected data" in such a case.
+
 ## [0.1.0] Initial release

--- a/packages/dataprotector-deserializer/src/index.ts
+++ b/packages/dataprotector-deserializer/src/index.ts
@@ -40,23 +40,31 @@ type Mode = 'optimistic' | 'legacy' | 'borsh';
  * - `protectedDataPath`: overrides the dataset path, by default use the standard dataset path provided in the iExec worker runtime
  */
 class IExecDataProtectorDeserializer {
-  private protectedDataPath: string;
+  private protectedDataPath?: string;
 
   private mode: Mode;
 
-  private zipPromise: Promise<JSZip>;
+  private zipPromise?: Promise<JSZip>;
 
   constructor(options?: { mode?: Mode; protectedDataPath?: string }) {
     this.mode = options?.mode || 'optimistic';
-    this.protectedDataPath =
-      options?.protectedDataPath ||
-      join(process.env.IEXEC_IN, process.env.IEXEC_DATASET_FILENAME);
-    this.zipPromise = readFile(this.protectedDataPath).then((buffer) => {
-      return new JSZip().loadAsync(buffer);
-    });
-    this.zipPromise.catch(() => {
-      /* prevents unhandled promise rejection */
-    });
+    if (options?.protectedDataPath) {
+      this.protectedDataPath = options?.protectedDataPath;
+    } else if (process.env.IEXEC_DATASET_FILENAME && process.env.IEXEC_IN) {
+      this.protectedDataPath = join(
+        process.env.IEXEC_IN,
+        process.env.IEXEC_DATASET_FILENAME
+      );
+    }
+
+    if (this.protectedDataPath) {
+      this.zipPromise = readFile(this.protectedDataPath).then((buffer) => {
+        return new JSZip().loadAsync(buffer);
+      });
+      this.zipPromise.catch(() => {
+        /* prevents unhandled promise rejection */
+      });
+    }
   }
 
   /**
@@ -93,6 +101,9 @@ class IExecDataProtectorDeserializer {
     | StringSchemaFilter<T>
     | BinarySchemaFilter<T>
   > {
+    if (this.zipPromise === undefined) {
+      throw Error('Missing protected data');
+    }
     const zip = await this.zipPromise.catch(() => {
       throw Error('Failed to load protected data');
     });

--- a/packages/dataprotector-deserializer/tests/index.test.ts
+++ b/packages/dataprotector-deserializer/tests/index.test.ts
@@ -2,8 +2,8 @@ import { writeFile } from 'fs/promises';
 import {
   createZipFromObject as legacyCreateZipFromObject,
   extractDataSchema as legacyExtractDataSchema,
-} from '@iexec/dataprotector/dist/utils/data.js'; // run `prepare-test-deps` script before running this test file
-import { describe, it, beforeAll, expect } from '@jest/globals';
+} from '@iexec/dataprotector/dist/utils/data.js'; // run `test:prepare` script before running this test file
+import { describe, it, beforeAll, expect, beforeEach } from '@jest/globals';
 import {
   createZipFromObject,
   extractDataSchema,
@@ -11,6 +11,11 @@ import {
 import { IExecDataProtectorDeserializer } from '../src/index.js';
 
 describe('IExecDataProtectorDeserializer', () => {
+  beforeEach(() => {
+    // reset env
+    delete process.env.IEXEC_IN;
+    delete process.env.IEXEC_DATASET_FILENAME;
+  });
   describe('constructor', () => {
     it('set default protectedDataPath with iexec envs', () => {
       process.env.IEXEC_IN = 'iexec_in';
@@ -25,6 +30,15 @@ describe('IExecDataProtectorDeserializer', () => {
       const protectedDataDeserializer = new IExecDataProtectorDeserializer();
       // eslint-disable-next-line @typescript-eslint/dot-notation
       expect(protectedDataDeserializer['mode']).toBe('optimistic');
+    });
+  });
+  describe('when used without protected data', () => {
+    it('getValue() fails to load the data', async () => {
+      // process.env.IEXEC_IN = 'iexec_in';
+      const protectedDataDeserializer = new IExecDataProtectorDeserializer();
+      await expect(
+        protectedDataDeserializer.getValue('foo', 'string')
+      ).rejects.toThrow(Error('Missing protected data'));
     });
   });
   describe('with a file that is not a protected data', () => {

--- a/packages/dataprotector-deserializer/tests/index.test.ts
+++ b/packages/dataprotector-deserializer/tests/index.test.ts
@@ -33,8 +33,8 @@ describe('IExecDataProtectorDeserializer', () => {
     });
   });
   describe('when used without protected data', () => {
-    it('getValue() fails to load the data', async () => {
-      // process.env.IEXEC_IN = 'iexec_in';
+    it('getValue() fails with missing protected data', async () => {
+      process.env.IEXEC_IN = 'iexec_in';
       const protectedDataDeserializer = new IExecDataProtectorDeserializer();
       await expect(
         protectedDataDeserializer.getValue('foo', 'string')


### PR DESCRIPTION
Fixed cryptic TypeError when `@iexec/dataprotector-deserializer` was used in a context without protected data, `getValue()` now rejects with Error "Missing protected data" in such a case.

Example with iapp hello-world template:

Before:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
```

After:
```
Error: Missing protected data
```