### PR TITLE
ci: add workflows for conventional commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,9 +1,6 @@
 name: Conventional Commits
 
-on:
-  pull_request:
-    branches:
-      - '*'
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,15 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: webiny/action-conventional-commits@v1.3.0


### PR DESCRIPTION
This pull request introduces a new GitHub Action workflow to enforce conventional commit messages on pull requests. The main change involves creating a new workflow configuration file.

New GitHub Action workflow:

* [`.github/workflows/conventional-commits.yml`](diffhunk://#diff-f9885af19817980378f57069d1ab25748e068abca2fd23f7d4e334a642deee8dR1-R15): Added a new workflow named "Conventional Commits" that triggers on pull requests to any branch. It uses the `actions/checkout@v4` and `webiny/action-conventional-commits@v1.3.0` actions to ensure commit messages follow the conventional commit format.