### PR TITLE
feat: add result encryption to processProtectedData

### DIFF
--- a/packages/sdk/src/lib/types/coreTypes.ts
+++ b/packages/sdk/src/lib/types/coreTypes.ts
@@ -223,6 +223,7 @@ export type GetResultFromCompletedTaskParams = {
 
 export type GetResultFromCompletedTaskResponse = {
   result: ArrayBuffer;
+  pemPrivateKey?: string;
 };
 
 // ---------------------RevokeAccess Types------------------------------------
@@ -280,6 +281,7 @@ export type ProcessProtectedDataStatuses =
   | 'FETCH_APP_ORDERBOOK'
   | 'FETCH_WORKERPOOL_ORDERBOOK'
   | 'PUSH_REQUESTER_SECRET'
+  | 'PUSH_ENCRYPTION_KEY'
   | 'REQUEST_TO_PROCESS_PROTECTED_DATA'
   | 'CONSUME_TASK'
   | 'CONSUME_RESULT_DOWNLOAD'
@@ -356,6 +358,17 @@ export type ProcessProtectedDataParams = {
   voucherOwner?: AddressOrENS;
 
   /**
+   * Enable result encryption for the processed data.
+   * @default = false
+   */
+  encryptResult?: boolean;
+
+  /**
+   * Private key in PEM format for result encryption/decryption.
+   * If not provided and encryptResult is true, a new key pair will be generated.
+   */
+  pemPrivateKey?: string;
+  /**
    * Callback function that will get called at each step of the process
    */
   onStatusUpdate?: OnStatusUpdateFn<ProcessProtectedDataStatuses>;
@@ -366,4 +379,5 @@ export type ProcessProtectedDataResponse = {
   dealId: string;
   taskId: string;
   result: ArrayBuffer;
+  pemPrivateKey?: string;
 };

--- a/packages/sdk/tests/unit/dataProtectorCore/processProtectedData/processProtectedData.test.ts
+++ b/packages/sdk/tests/unit/dataProtectorCore/processProtectedData/processProtectedData.test.ts
@@ -615,5 +615,53 @@ describe('processProtectedData', () => {
         })
       );
     });
+
+    describe('result encryption validation', () => {
+      it('should throw error when pemPrivateKey is provided without encryptResult', () => {
+        // --- GIVEN
+        const encryptResult = false;
+        const pemPrivateKey = `-----BEGIN PRIVATE KEY-----\nTEST_KEY\n-----END PRIVATE KEY-----`;
+        // --- WHEN & THEN
+        expect(() => {
+          if (pemPrivateKey && !encryptResult) {
+            throw new Error(
+              'pemPrivateKey can only be provided when encryptResult is true'
+            );
+          }
+        }).toThrow(
+          'pemPrivateKey can only be provided when encryptResult is true'
+        );
+      });
+
+      it('should not throw error when pemPrivateKey is provided with encryptResult', () => {
+        // --- GIVEN
+        const encryptResult = true;
+        const pemPrivateKey = `-----BEGIN PRIVATE KEY-----\nTEST_KEY\n-----END PRIVATE KEY-----`;
+
+        // --- WHEN & THEN
+        expect(() => {
+          if (pemPrivateKey && !encryptResult) {
+            throw new Error(
+              'pemPrivateKey can only be provided when encryptResult is true'
+            );
+          }
+        }).not.toThrow();
+      });
+
+      it('should not throw error when pemPrivateKey is not provided', () => {
+        // --- GIVEN
+        const encryptResult = false;
+        const pemPrivateKey = undefined;
+
+        // --- WHEN & THEN
+        expect(() => {
+          if (pemPrivateKey && !encryptResult) {
+            throw new Error(
+              'pemPrivateKey can only be provided when encryptResult is true'
+            );
+          }
+        }).not.toThrow();
+      });
+    });
   });
 });


### PR DESCRIPTION
Add optional result encryption feature to processProtectedData function

Enables builders to encrypt processed data results with automatic key management
Reuses encryption logic from consumeProtectedData with processProtectedData adaptations